### PR TITLE
Added tests for 4 page* wrappers

### DIFF
--- a/force-app/main/default/lwc/pageBlocksWrapper/__tests__/pageBlocksWrapper.test.js
+++ b/force-app/main/default/lwc/pageBlocksWrapper/__tests__/pageBlocksWrapper.test.js
@@ -9,7 +9,7 @@ describe('c-page-blocks-wrapper', () => {
         }
     });
 
-    it('shows inner component using c-page-blocks-wrapper', () => {
+    it('shows inner component using c-example-wrapper', () => {
         // Create initial element
         const element = createElement('c-page-blocks-wrapper', {
             is: PageBlocksWrapper

--- a/force-app/main/default/lwc/pageBlocksWrapper/__tests__/pageBlocksWrapper.test.js
+++ b/force-app/main/default/lwc/pageBlocksWrapper/__tests__/pageBlocksWrapper.test.js
@@ -1,0 +1,25 @@
+import { createElement } from 'lwc';
+import PageBlocksWrapper from 'c/pageBlocksWrapper';
+
+describe('c-page-blocks-wrapper', () => {
+    afterEach(() => {
+        // The jsdom instance is shared across test cases in a single file so reset the DOM
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+    });
+
+    it('shows inner component using c-page-blocks-wrapper', () => {
+        // Create initial element
+        const element = createElement('c-page-blocks-wrapper', {
+            is: PageBlocksWrapper
+        });
+        document.body.appendChild(element);
+
+        const exampleEl = element.shadowRoot.querySelector('c-example-wrapper');
+        expect(exampleEl).not.toBeNull();
+
+        const innerEl = exampleEl.querySelector('c-page-blocks');
+        expect(innerEl).not.toBeNull();
+    });
+});

--- a/force-app/main/default/lwc/pageMessagesFormWrapper/__tests__/pageMessagesFormWrapper.test.js
+++ b/force-app/main/default/lwc/pageMessagesFormWrapper/__tests__/pageMessagesFormWrapper.test.js
@@ -9,7 +9,7 @@ describe('c-page-messages-form-wrapper', () => {
         }
     });
 
-    it('shows inner component using c-page-messages-form-wrapper', () => {
+    it('shows inner component using c-example-wrapper', () => {
         // Create initial element
         const element = createElement('c-page-messages-form-wrapper', {
             is: PageMessagesFormWrapper

--- a/force-app/main/default/lwc/pageMessagesFormWrapper/__tests__/pageMessagesFormWrapper.test.js
+++ b/force-app/main/default/lwc/pageMessagesFormWrapper/__tests__/pageMessagesFormWrapper.test.js
@@ -1,0 +1,25 @@
+import { createElement } from 'lwc';
+import PageMessagesFormWrapper from 'c/pageMessagesFormWrapper';
+
+describe('c-page-messages-form-wrapper', () => {
+    afterEach(() => {
+        // The jsdom instance is shared across test cases in a single file so reset the DOM
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+    });
+
+    it('shows inner component using c-page-messages-form-wrapper', () => {
+        // Create initial element
+        const element = createElement('c-page-messages-form-wrapper', {
+            is: PageMessagesFormWrapper
+        });
+        document.body.appendChild(element);
+
+        const exampleEl = element.shadowRoot.querySelector('c-example-wrapper');
+        expect(exampleEl).not.toBeNull();
+
+        const innerEl = exampleEl.querySelector('c-page-messages-form');
+        expect(innerEl).not.toBeNull();
+    });
+});

--- a/force-app/main/default/lwc/pageMessagesToastWrapper/__tests__/pageMessagesToastWrapper.test.js
+++ b/force-app/main/default/lwc/pageMessagesToastWrapper/__tests__/pageMessagesToastWrapper.test.js
@@ -9,7 +9,7 @@ describe('c-page-messages-toast-wrapper', () => {
         }
     });
 
-    it('shows inner component using c-page-messages-toast-wrapper', () => {
+    it('shows inner component using c-example-wrapper', () => {
         // Create initial element
         const element = createElement('c-page-messages-toast-wrapper', {
             is: PageMessagesToastWrapper

--- a/force-app/main/default/lwc/pageMessagesToastWrapper/__tests__/pageMessagesToastWrapper.test.js
+++ b/force-app/main/default/lwc/pageMessagesToastWrapper/__tests__/pageMessagesToastWrapper.test.js
@@ -1,0 +1,25 @@
+import { createElement } from 'lwc';
+import PageMessagesToastWrapper from 'c/pageMessagesToastWrapper';
+
+describe('c-page-messages-toast-wrapper', () => {
+    afterEach(() => {
+        // The jsdom instance is shared across test cases in a single file so reset the DOM
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+    });
+
+    it('shows inner component using c-page-messages-toast-wrapper', () => {
+        // Create initial element
+        const element = createElement('c-page-messages-toast-wrapper', {
+            is: PageMessagesToastWrapper
+        });
+        document.body.appendChild(element);
+
+        const exampleEl = element.shadowRoot.querySelector('c-example-wrapper');
+        expect(exampleEl).not.toBeNull();
+
+        const innerEl = exampleEl.querySelector('c-page-messages-toast');
+        expect(innerEl).not.toBeNull();
+    });
+});

--- a/force-app/main/default/lwc/paginatedListWrapper/__tests__/paginatedListWrapper.test.js
+++ b/force-app/main/default/lwc/paginatedListWrapper/__tests__/paginatedListWrapper.test.js
@@ -1,0 +1,25 @@
+import { createElement } from 'lwc';
+import PaginatedListWrapper from 'c/paginatedListWrapper';
+
+describe('c-page-messages-toast-wrapper', () => {
+    afterEach(() => {
+        // The jsdom instance is shared across test cases in a single file so reset the DOM
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+    });
+
+    it('shows inner component using c-paginated-list-wrapper', () => {
+        // Create initial element
+        const element = createElement('c-paginated-list-wrapper', {
+            is: PaginatedListWrapper
+        });
+        document.body.appendChild(element);
+
+        const exampleEl = element.shadowRoot.querySelector('c-example-wrapper');
+        expect(exampleEl).not.toBeNull();
+
+        const innerEl = exampleEl.querySelector('c-paginated-list');
+        expect(innerEl).not.toBeNull();
+    });
+});

--- a/force-app/main/default/lwc/paginatedListWrapper/__tests__/paginatedListWrapper.test.js
+++ b/force-app/main/default/lwc/paginatedListWrapper/__tests__/paginatedListWrapper.test.js
@@ -9,7 +9,7 @@ describe('c-page-messages-toast-wrapper', () => {
         }
     });
 
-    it('shows inner component using c-paginated-list-wrapper', () => {
+    it('shows inner component using c-example-wrapper', () => {
         // Create initial element
         const element = createElement('c-paginated-list-wrapper', {
             is: PaginatedListWrapper


### PR DESCRIPTION
Added tests for 4 page* wrappers.
These are all using the same test pattern (only tag and class names vary) so I grouped them in the same PR to speed up review and PR management.