### PR TITLE
Test suite for tabs wrapper

### DIFF
--- a/force-app/main/default/lwc/tabsWrapper/__tests__/tabsWrapper.test.js
+++ b/force-app/main/default/lwc/tabsWrapper/__tests__/tabsWrapper.test.js
@@ -1,0 +1,25 @@
+import { createElement } from 'lwc';
+import TabsWrapper from 'c/tabsWrapper';
+
+describe('c-tabs-wrapper', () => {
+    afterEach(() => {
+        // The jsdom instance is shared across test cases in a single file so reset the DOM
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+    });
+
+    it('shows inner component using c-tabs-wrapper', () => {
+        const element = createElement('c-tabs-wrapper', {
+            is: TabsWrapper
+        });
+        document.body.appendChild(element);
+
+        // Verify required child components are present on render.
+        const exampleEl = element.shadowRoot.querySelector('c-example-wrapper');
+        expect(exampleEl).not.toBeNull();
+
+        const innerEl = exampleEl.querySelector('c-tabs');
+        expect(innerEl).not.toBeNull();
+    });
+});

--- a/force-app/main/default/lwc/tabsWrapper/__tests__/tabsWrapper.test.js
+++ b/force-app/main/default/lwc/tabsWrapper/__tests__/tabsWrapper.test.js
@@ -9,7 +9,7 @@ describe('c-tabs-wrapper', () => {
         }
     });
 
-    it('shows inner component using c-tabs-wrapper', () => {
+    it('shows inner component using c-example-wrapper', () => {
         const element = createElement('c-tabs-wrapper', {
             is: TabsWrapper
         });


### PR DESCRIPTION
Adds tests for `c/tabsWrapper` component. Followed example format in `c/paginatedListWrapper` here: https://github.com/trailheadapps/visualforce-to-lwc/blob/prerelease/summer20/force-app/main/default/lwc/paginatedListWrapper/__tests__/paginatedListWrapper.test.js