### PR TITLE
Prerelease/navigate to record tests

### DIFF
--- a/force-app/main/default/lwc/navigateToRecord/__tests__/navigateToRecord.test.js
+++ b/force-app/main/default/lwc/navigateToRecord/__tests__/navigateToRecord.test.js
@@ -1,0 +1,50 @@
+import { createElement } from 'lwc';
+import NavigateToRecord from 'c/navigateToRecord';
+import { getNavigateCalledWith } from 'lightning/navigation';
+
+describe('c-navigate-to-record', () => {
+    afterEach(() => {
+        // The jsdom instance is shared across test cases in a single file so reset the DOM
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+    });
+    it('navigates to record view by ID', () => {
+        const element = createElement('c-navigate-to-record', {
+            is: NavigateToRecord
+        });
+        element.label = 'foo';
+        element.recordId = '0031700000pJRRTAA4';
+        document.body.appendChild(element);
+
+        return Promise.resolve().then(() => {
+            // Get handle to anchor and fire click event
+            const anchorEl = element.shadowRoot.querySelector('a');
+            expect(anchorEl).not.toBeNull();
+            anchorEl.click();
+
+            const { pageReference } = getNavigateCalledWith();
+
+            expect(pageReference.type).toEqual('standard__recordPage');
+            expect(pageReference.attributes.recordId).toEqual(element.recordId);
+            expect(pageReference.attributes.actionName).toEqual('view');
+        });
+    });
+
+    it('creates an anchor element with a blank target, # href and label', () => {
+        const element = createElement('c-navigate-to-record', {
+            is: NavigateToRecord
+        });
+        element.label = 'foo';
+        document.body.appendChild(element);
+
+        return Promise.resolve().then(() => {
+            // Get handle to anchor and fire click event
+            const anchorEl = element.shadowRoot.querySelector('a');
+            expect(anchorEl).not.toBeNull();
+            expect(anchorEl.textContent).toEqual(element.label);
+            expect.stringMatching(anchorEl.href, /#$/);
+            expect(anchorEl.target).toEqual('_blank');
+        });
+    });
+});

--- a/force-app/main/default/lwc/navigateToRecord/__tests__/navigateToRecord.test.js
+++ b/force-app/main/default/lwc/navigateToRecord/__tests__/navigateToRecord.test.js
@@ -9,6 +9,7 @@ describe('c-navigate-to-record', () => {
             document.body.removeChild(document.body.firstChild);
         }
     });
+
     it('navigates to record view by ID', () => {
         const element = createElement('c-navigate-to-record', {
             is: NavigateToRecord
@@ -31,7 +32,7 @@ describe('c-navigate-to-record', () => {
         });
     });
 
-    it('creates an anchor element with a blank target, # href and label', () => {
+    it('creates an anchor element with the right label', () => {
         const element = createElement('c-navigate-to-record', {
             is: NavigateToRecord
         });
@@ -43,8 +44,6 @@ describe('c-navigate-to-record', () => {
             const anchorEl = element.shadowRoot.querySelector('a');
             expect(anchorEl).not.toBeNull();
             expect(anchorEl.textContent).toEqual(element.label);
-            expect.stringMatching(anchorEl.href, /#$/);
-            expect(anchorEl.target).toEqual('_blank');
         });
     });
 });

--- a/force-app/test/jest-mocks/lightning/navigation.js
+++ b/force-app/test/jest-mocks/lightning/navigation.js
@@ -1,0 +1,41 @@
+/**
+ * For the original lightning/navigation mock that comes by default with
+ * @salesforce/sfdx-lwc-jest, see:
+ * https://github.com/salesforce/sfdx-lwc-jest/blob/master/src/lightning-stubs/navigation/navigation.js
+ */
+export const CurrentPageReference = jest.fn();
+
+let _navigatePageReference, _generatePageReference, _replace;
+
+const Navigate = Symbol('Navigate');
+const GenerateUrl = Symbol('GenerateUrl');
+export const NavigationMixin = (Base) => {
+    return class extends Base {
+        [Navigate](pageReference, replace) {
+            _navigatePageReference = pageReference;
+            _replace = replace;
+        }
+        [GenerateUrl](pageReference) {
+            _generatePageReference = pageReference;
+            return new Promise((resolve) => resolve('https://www.example.com'));
+        }
+    };
+};
+NavigationMixin.Navigate = Navigate;
+NavigationMixin.GenerateUrl = GenerateUrl;
+
+/*
+ * Tests do not have access to the internals of this mixin used by the
+ * component under test so save a reference to the arguments the Navigate method is
+ * invoked with and provide access with this function.
+ */
+export const getNavigateCalledWith = () => {
+    return {
+        pageReference: _navigatePageReference,
+        replace: _replace
+    };
+};
+
+export const getGenerateUrlCalledWith = () => ({
+    pageReference: _generatePageReference
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,8 @@ module.exports = {
     ...jestConfig,
     moduleNameMapper: {
         '^@salesforce/schema$': '<rootDir>/force-app/test/jest-mocks/schema',
+        '^lightning/navigation$':
+            '<rootDir>/force-app/test/jest-mocks/lightning/navigation',
         '^lightning/platformShowToastEvent$':
             '<rootDir>/force-app/test/jest-mocks/lightning/platformShowToastEvent'
     }


### PR DESCRIPTION
### What does this PR do?

Adds tests to the navigateToRecord LWC. 
As part of the tests, it adds a new tests/lightning/navigation.js stub for the navigation mixin. Pulled from lwc-recipes verbatim.
It also adds a mapping clause to the jest.config.js file.

## The PR fulfills these requirements:

[x] Tests for the proposed changes have been added/updated.
[x] Code linting and formatting was performed.

### Functionality After

<insert gif and/or summary>
![image](https://user-images.githubusercontent.com/642589/87803608-bafef080-c820-11ea-8c2b-efb94d68c0e0.png)

