### PR TITLE
Codefriar/page messages data retrieval wrapper tests

### DIFF
--- a/force-app/main/default/lwc/pageMessagesDataRetrieval/__mocks__/pageMessagesDataRetrieval.js
+++ b/force-app/main/default/lwc/pageMessagesDataRetrieval/__mocks__/pageMessagesDataRetrieval.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class PageMessagesDataRetrieval extends LightningElement {}

--- a/force-app/main/default/lwc/pageMessagesDataRetrievalWrapper/__tests__/pageMessageDataMessagesRetrievalWrapper.test.js
+++ b/force-app/main/default/lwc/pageMessagesDataRetrievalWrapper/__tests__/pageMessageDataMessagesRetrievalWrapper.test.js
@@ -1,0 +1,31 @@
+import { createElement } from 'lwc';
+import PageMessagesDataRetrievalWrapper from 'c/pageMessagesDataRetrievalWrapper';
+
+jest.mock('../../pageMessagesDataRetrieval/pageMessagesDataRetrieval');
+
+describe('c-page-messages-data-retrieval-wrapper', () => {
+    afterEach(() => {
+        // The jsdom instance is shared across test cases in a single file so reset the DOM
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+    });
+    it('shows inner component using c-example-wrapper', () => {
+        // Create initial element
+        const element = createElement(
+            'c-page-messages-data-retrieval-wrapper',
+            {
+                is: PageMessagesDataRetrievalWrapper
+            }
+        );
+        document.body.appendChild(element);
+
+        const exampleEl = element.shadowRoot.querySelector('c-example-wrapper');
+        expect(exampleEl).not.toBeNull();
+
+        const innerEl = exampleEl.querySelector(
+            'c-page-messages-data-retrieval'
+        );
+        expect(innerEl).not.toBeNull();
+    });
+});


### PR DESCRIPTION
### What does this PR do?
Adds PageMessagesDataRetrievalWrapper tests
![image](https://user-images.githubusercontent.com/642589/88228463-34417d80-cc3d-11ea-882e-4948ae6db71a.png)
