### PR TITLE
Remove instructions to activate my domain from README as it comes activated by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,6 @@ Make sure to start from a brand-new environment to avoid conflicts with previous
 
 1. Log in to your org
 
-1. If you are setting up a Developer Edition: go to **Setup**, under **My Domain**, [register a My Domain](https://help.salesforce.com/articleView?id=domain_name_setup.htm&type=5).
-
 1. Start an In-App Guidance trial
 
     - In Setup, navigate to **_User Engagement > In-App Guidance_**.
@@ -150,8 +148,6 @@ Make sure to start from a brand-new environment to avoid conflicts with previous
     ```
     sfdx force:auth:web:login -s -a mydevorg
     ```
-
-1. If you are setting up a Developer Edition: go to **Setup**, under **My Domain**, [register a My Domain](https://help.salesforce.com/articleView?id=domain_name_setup.htm&type=5).
 
 1. Start an In-App Guidance trial
 


### PR DESCRIPTION
### What does this PR do?
Removes my domain activation from instructions as it comes setup by default on dev orgs now

### What issues does this PR fix or reference?

#103 

## The PR fulfills these requirements:

[N/A] Tests for the proposed changes have been added/updated.
[X] Code linting and formatting was performed.

### Functionality Before
There were instructions to activate my domain on README

### Functionality After
There are no instructions to activate my domain from README as it comes activated by default
