### PR TITLE
Removes unneeded "force" namespace from README auth commands

### DIFF
--- a/.github/workflows/scratch-org-sfdx-ci-pr-prerelease.yml
+++ b/.github/workflows/scratch-org-sfdx-ci-pr-prerelease.yml
@@ -58,20 +58,16 @@ jobs:
         needs: formatting-and-linting
         steps:
             # Install Salesforce CLI
-            - name: Install Salesforce CLI
-              run: |
-                  wget https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz
-                  mkdir sfdx-cli
-                  tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
-                  ./sfdx-cli/install
-
-            # Checkout the code in the pull request
-            - name: 'Checkout source code'
-              uses: actions/checkout@v2
+            - name: 'Install Salesforce CLI'
+              run: 'sudo npm install -g sfdx-cli'
 
             # Install salesforcedx pre-release plugin
             - name: 'Install salesforcedx pre-release plugin'
               run: 'sfdx plugins:install salesforcedx@pre-release'
+
+            # Checkout the code in the pull request
+            - name: 'Checkout source code'
+              uses: actions/checkout@v2
 
             # Store secret for dev hub
             - name: 'Populate auth file with DEVHUB_PREREL_SFDX_URL secret'

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Make sure to start from a brand-new environment to avoid conflicts with previous
 1. Authorize with your Trailhead Playground or Developer org and provide it with an alias (**mydevorg** in the command below):
 
     ```
-    sfdx force:auth:web:login -s -a mydevorg
+    sfdx auth:web:login -s -a mydevorg
     ```
 
 1. Start an In-App Guidance trial


### PR DESCRIPTION
### What does this PR do?
Removes unneeded "force" namespace from README auth commands

### What issues does this PR fix or reference?

#<Insert GitHub Issue>

## The PR fulfills these requirements:

[N/A] Tests for the proposed changes have been added/updated.
[N/A] Code linting and formatting was performed.

### Functionality Before
README used auth commands with the force namespace

### Functionality After
README doesn't use the force namespace on auth commands as it's no longer needed (https://github.com/forcedotcom/cli/blob/main/releasenotes/README.md)