### PR TITLE
Refactor tests to use async await

### DIFF
--- a/force-app/main/default/lwc/basicListGetListUi/__tests__/basicListGetListUi.test.js
+++ b/force-app/main/default/lwc/basicListGetListUi/__tests__/basicListGetListUi.test.js
@@ -48,7 +48,13 @@ describe('c-basic-list-get-list-ui', () => {
         jest.clearAllMocks();
     });
 
-    it('renders lightning-datatable when there is data', () => {
+    // Helper function to wait until the microtask queue is empty.
+    // Used to wait for asynchronous DOM updates.
+    async function flushPromises() {
+        return Promise.resolve();
+    }
+
+    it('renders lightning-datatable when there is data', async () => {
         // Create initial element
         const element = createElement('c-basic-list-get-list-ui', {
             is: BasicListGetListUi
@@ -61,21 +67,19 @@ describe('c-basic-list-get-list-ui', () => {
         // Emit data from @wire
         getListUiAdapter.emit(mockGetListUi);
 
-        // Return a promise to wait for any asynchronous DOM updates. Jest
-        // will automatically wait for the Promise chain to complete before
-        // ending the test and fail the test if the promise rejects.
-        return Promise.resolve().then(() => {
-            const datatableEl = element.shadowRoot.querySelector(
-                'lightning-datatable'
-            );
-            expect(formatGetListUiSObjects).toHaveBeenCalledWith(mockGetListUi);
-            expect(datatableEl).not.toBeNull();
-            expect(datatableEl.data).toStrictEqual(mockFormatGetListUiSObjects);
-            expect(datatableEl.columns).toStrictEqual(COLUMNS);
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        const datatableEl = element.shadowRoot.querySelector(
+            'lightning-datatable'
+        );
+        expect(formatGetListUiSObjects).toHaveBeenCalledWith(mockGetListUi);
+        expect(datatableEl).not.toBeNull();
+        expect(datatableEl.data).toStrictEqual(mockFormatGetListUiSObjects);
+        expect(datatableEl.columns).toStrictEqual(COLUMNS);
     });
 
-    it('renders error panel when there is error', () => {
+    it('renders error panel when there is error', async () => {
         // Create initial element
         const element = createElement('c-basic-list-get-list-ui', {
             is: BasicListGetListUi
@@ -85,18 +89,15 @@ describe('c-basic-list-get-list-ui', () => {
         // Emit data from @wire
         getListUiAdapter.error();
 
-        // Return a promise to wait for any asynchronous DOM updates. Jest
-        // will automatically wait for the Promise chain to complete before
-        // ending the test and fail the test if the promise rejects.
-        return Promise.resolve().then(() => {
-            const errorPanelEl =
-                element.shadowRoot.querySelector('c-error-panel');
-            expect(errorPanelEl).not.toBeNull();
-            expect(errorPanelEl.errors).toBeTruthy();
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        const errorPanelEl = element.shadowRoot.querySelector('c-error-panel');
+        expect(errorPanelEl).not.toBeNull();
+        expect(errorPanelEl.errors).toBeTruthy();
     });
 
-    it('is accessible when data is returned', () => {
+    it('is accessible when data is returned', async () => {
         // Create initial element
         const element = createElement('c-basic-list-get-list-ui', {
             is: BasicListGetListUi
@@ -109,10 +110,13 @@ describe('c-basic-list-get-list-ui', () => {
         // Emit data from @wire
         getListUiAdapter.emit(mockGetListUi);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        await expect(element).toBeAccessible();
     });
 
-    it('is accessible when error is returned', () => {
+    it('is accessible when error is returned', async () => {
         // Create initial element
         const element = createElement('c-basic-list-get-list-ui', {
             is: BasicListGetListUi
@@ -122,6 +126,9 @@ describe('c-basic-list-get-list-ui', () => {
         // Emit data from @wire
         getListUiAdapter.error();
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/basicListGetListUiWrapper/__tests__/basicListGetListUiWrapper.test.js
+++ b/force-app/main/default/lwc/basicListGetListUiWrapper/__tests__/basicListGetListUiWrapper.test.js
@@ -14,6 +14,12 @@ describe('c-basic-list-get-list-ui-wrapper', () => {
             document.body.removeChild(document.body.firstChild);
         }
     });
+
+    // Helper function to wait until the microtask queue is empty.
+    // Used to wait for asynchronous DOM updates.
+    async function flushPromises() {
+        return Promise.resolve();
+    }
     it('shows inner component using c-example-wrapper', () => {
         // Create initial element
         const element = createElement('c-basic-list-get-list-ui-wrapper', {
@@ -28,13 +34,16 @@ describe('c-basic-list-get-list-ui-wrapper', () => {
         expect(innerEl).not.toBeNull();
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-basic-list-get-list-ui-wrapper', {
             is: BasicListGetListUiWrapper
         });
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/createMixedRecordsApex/__tests__/createMixedRecordsApex.test.js
+++ b/force-app/main/default/lwc/createMixedRecordsApex/__tests__/createMixedRecordsApex.test.js
@@ -36,11 +36,10 @@ describe('c-create-mixed-records-apex', () => {
         jest.clearAllMocks();
     });
 
-    // Helper function to wait until the microtask queue is empty. This is needed for promise
-    // timing when calling imperative Apex.
-    function flushPromises() {
-        // eslint-disable-next-line no-undef
-        return new Promise((resolve) => setImmediate(resolve));
+    // Helper function to wait until the microtask queue is empty.
+    // Used to wait for asynchronous DOM updates.
+    async function flushPromises() {
+        return Promise.resolve();
     }
 
     it('initializes lightning-input values correctly', () => {
@@ -58,7 +57,7 @@ describe('c-create-mixed-records-apex', () => {
         expect(actualValues).toEqual(DEFAULT_VALUES);
     });
 
-    it('passes the user input to the Apex method correctly', () => {
+    it('passes the user input to the Apex method correctly', async () => {
         const CONTACT_FIRST_NAME = 'John';
         const CONTACT_LAST_NAME = 'Taylor';
         const OPPORTUNITY_NAME = 'Big deal!';
@@ -100,19 +99,16 @@ describe('c-create-mixed-records-apex', () => {
         const buttonEl = element.shadowRoot.querySelector('lightning-button');
         buttonEl.click();
 
-        // Return an immediate flushed promise (after the Apex call) to then
-        // wait for any asynchronous DOM updates. Jest will automatically wait
-        // for the Promise chain to complete before ending the test and fail
-        // the test if the promise ends in the rejected state.
-        return flushPromises().then(() => {
-            // Validate parameters of mocked Apex call
-            expect(createContactAndOpportunity.mock.calls[0][0]).toEqual(
-                APEX_PARAMETERS
-            );
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        // Validate parameters of mocked Apex call
+        expect(createContactAndOpportunity.mock.calls[0][0]).toEqual(
+            APEX_PARAMETERS
+        );
     });
 
-    it('shows success toast message when records created successfully', () => {
+    it('shows success toast message when records created successfully', async () => {
         // Assign mock value for resolved Apex promise
         createContactAndOpportunity.mockResolvedValue(APEX_OPERATION_SUCCESS);
 
@@ -131,21 +127,18 @@ describe('c-create-mixed-records-apex', () => {
         const buttonEl = element.shadowRoot.querySelector('lightning-button');
         buttonEl.click();
 
-        // Return an immediate flushed promise (after the Apex call) to then
-        // wait for any asynchronous DOM updates. Jest will automatically wait
-        // for the Promise chain to complete before ending the test and fail
-        // the test if the promise ends in the rejected state.
-        return flushPromises().then(() => {
-            // Check if toast event has been fired
-            expect(handler).toHaveBeenCalled();
-            expect(handler.mock.calls[0][0].detail.variant).toBe('success');
-            expect(handler.mock.calls[0][0].detail.message).toBe(
-                'Contact & Opportunity created correctly'
-            );
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        // Check if toast event has been fired
+        expect(handler).toHaveBeenCalled();
+        expect(handler.mock.calls[0][0].detail.variant).toBe('success');
+        expect(handler.mock.calls[0][0].detail.message).toBe(
+            'Contact & Opportunity created correctly'
+        );
     });
 
-    it('shows error toast message when there is an error', () => {
+    it('shows error toast message when there is an error', async () => {
         // Assign mock value for rejected Apex promise
         createContactAndOpportunity.mockRejectedValue(APEX_OPERATION_ERROR);
 
@@ -164,28 +157,25 @@ describe('c-create-mixed-records-apex', () => {
         const buttonEl = element.shadowRoot.querySelector('lightning-button');
         buttonEl.click();
 
-        // Return an immediate flushed promise (after the Apex call) to then
-        // wait for any asynchronous DOM updates. Jest will automatically wait
-        // for the Promise chain to complete before ending the test and fail
-        // the test if the promise ends in the rejected state.
-        return flushPromises().then(() => {
-            // Check if toast event has been fired
-            expect(handler).toHaveBeenCalled();
-            expect(handler.mock.calls[0][0].detail.variant).toBe('error');
-            expect(handler.mock.calls[0][0].detail.message).toBe(
-                'Error creating records: ' +
-                    reduceErrors(APEX_OPERATION_ERROR).join(', ')
-            );
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        // Check if toast event has been fired
+        expect(handler).toHaveBeenCalled();
+        expect(handler.mock.calls[0][0].detail.variant).toBe('error');
+        expect(handler.mock.calls[0][0].detail.message).toBe(
+            'Error creating records: ' +
+                reduceErrors(APEX_OPERATION_ERROR).join(', ')
+        );
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-create-mixed-records-apex', {
             is: CreateMixedRecordsApex
         });
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/createMixedRecordsApexWrapper/__tests__/createMixedRecordsApexWrapper.test.js
+++ b/force-app/main/default/lwc/createMixedRecordsApexWrapper/__tests__/createMixedRecordsApexWrapper.test.js
@@ -11,6 +11,7 @@ describe('c-create-mixed-records-apex-wrapper', () => {
             document.body.removeChild(document.body.firstChild);
         }
     });
+
     it('shows inner component using c-example-wrapper', () => {
         // Create initial element
         const element = createElement('c-create-mixed-records-apex-wrapper', {
@@ -25,13 +26,13 @@ describe('c-create-mixed-records-apex-wrapper', () => {
         expect(innerEl).not.toBeNull();
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-create-mixed-records-apex-wrapper', {
             is: CreateMixedRecordsApexWrapper
         });
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/createMixedRecordsWireFunctionsWrapper/__tests__/createMixedRecordsWireFunctionsWrapper.test.js
+++ b/force-app/main/default/lwc/createMixedRecordsWireFunctionsWrapper/__tests__/createMixedRecordsWireFunctionsWrapper.test.js
@@ -30,7 +30,7 @@ describe('c-create-mixed-records-wire-functions-wrapper', () => {
         expect(innerEl).not.toBeNull();
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement(
             'c-create-mixed-records-wire-functions-wrapper',
             {
@@ -40,6 +40,6 @@ describe('c-create-mixed-records-wire-functions-wrapper', () => {
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/createRecordWithPrepopulatedValues/__tests__/createRecordWithPrepopulatedValues.test.js
+++ b/force-app/main/default/lwc/createRecordWithPrepopulatedValues/__tests__/createRecordWithPrepopulatedValues.test.js
@@ -9,7 +9,7 @@ describe('c-create-record-with-prepopulated-values', () => {
         }
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement(
             'c-create-record-with-prepopulated-values',
             {
@@ -18,6 +18,6 @@ describe('c-create-record-with-prepopulated-values', () => {
         );
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/createRecordWithPrepopulatedValuesWrapper/__tests__/createRecordWithPrepopulatedValuesWrapper.test.js
+++ b/force-app/main/default/lwc/createRecordWithPrepopulatedValuesWrapper/__tests__/createRecordWithPrepopulatedValuesWrapper.test.js
@@ -30,7 +30,7 @@ describe('c-create-record-with-prepopulated-values-wrapper', () => {
         expect(innerEl).not.toBeNull();
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement(
             'c-create-record-with-prepopulated-values-wrapper',
             {
@@ -40,6 +40,6 @@ describe('c-create-record-with-prepopulated-values-wrapper', () => {
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/editRecord/__tests__/editRecord.test.js
+++ b/force-app/main/default/lwc/editRecord/__tests__/editRecord.test.js
@@ -18,6 +18,13 @@ describe('c-edit-record', () => {
 
         jest.clearAllMocks();
     });
+
+    // Helper function to wait until the microtask queue is empty.
+    // Used to wait for asynchronous DOM updates.
+    async function flushPromises() {
+        return Promise.resolve();
+    }
+
     it('shows a lightning-record-form initialized', () => {
         // Create initial element
         const element = createElement('c-edit-record', {
@@ -40,7 +47,7 @@ describe('c-edit-record', () => {
     });
 
     describe('shows success toast message', () => {
-        it('when a record is created successfully', () => {
+        it('when a record is created successfully', async () => {
             // Create initial element
             const element = createElement('c-edit-record', {
                 is: EditRecord
@@ -58,20 +65,18 @@ describe('c-edit-record', () => {
             );
             recordForm.dispatchEvent(new CustomEvent('success'));
 
-            // Return a promise to wait for any asynchronous DOM updates. Jest
-            // will automatically wait for the Promise chain to complete before
-            // ending the test and fail the test if the promise rejects.
-            return Promise.resolve().then(() => {
-                // Check if toast event has been fired
-                expect(handler).toHaveBeenCalled();
-                expect(handler.mock.calls[0][0].detail.variant).toBe('success');
-                expect(handler.mock.calls[0][0].detail.message).toBe(
-                    'Account created'
-                );
-            });
+            // Wait for any asynchronous DOM updates
+            await flushPromises();
+
+            // Check if toast event has been fired
+            expect(handler).toHaveBeenCalled();
+            expect(handler.mock.calls[0][0].detail.variant).toBe('success');
+            expect(handler.mock.calls[0][0].detail.message).toBe(
+                'Account created'
+            );
         });
 
-        it('when a record is updated successfully', () => {
+        it('when a record is updated successfully', async () => {
             // Create initial element
             const element = createElement('c-edit-record', {
                 is: EditRecord
@@ -90,22 +95,20 @@ describe('c-edit-record', () => {
             );
             recordForm.dispatchEvent(new CustomEvent('success'));
 
-            // Return a promise to wait for any asynchronous DOM updates. Jest
-            // will automatically wait for the Promise chain to complete before
-            // ending the test and fail the test if the promise rejects.
-            return Promise.resolve().then(() => {
-                // Check if toast event has been fired
-                expect(handler).toHaveBeenCalled();
-                expect(handler.mock.calls[0][0].detail.variant).toBe('success');
-                expect(handler.mock.calls[0][0].detail.message).toBe(
-                    'Account updated'
-                );
-            });
+            // Wait for any asynchronous DOM updates
+            await flushPromises();
+
+            // Check if toast event has been fired
+            expect(handler).toHaveBeenCalled();
+            expect(handler.mock.calls[0][0].detail.variant).toBe('success');
+            expect(handler.mock.calls[0][0].detail.message).toBe(
+                'Account updated'
+            );
         });
     });
 
     describe('shows error toast message', () => {
-        it('when there is an error creating a record', () => {
+        it('when there is an error creating a record', async () => {
             // Create initial element
             const element = createElement('c-edit-record', {
                 is: EditRecord
@@ -123,20 +126,18 @@ describe('c-edit-record', () => {
             );
             recordForm.dispatchEvent(new CustomEvent('error'));
 
-            // Return a promise to wait for any asynchronous DOM updates. Jest
-            // will automatically wait for the Promise chain to complete before
-            // ending the test and fail the test if the promise rejects.
-            return Promise.resolve().then(() => {
-                // Check if toast event has been fired
-                expect(handler).toHaveBeenCalled();
-                expect(handler.mock.calls[0][0].detail.variant).toBe('error');
-                expect(handler.mock.calls[0][0].detail.message).toBe(
-                    'Error creating Account'
-                );
-            });
+            // Wait for any asynchronous DOM updates
+            await flushPromises();
+
+            // Check if toast event has been fired
+            expect(handler).toHaveBeenCalled();
+            expect(handler.mock.calls[0][0].detail.variant).toBe('error');
+            expect(handler.mock.calls[0][0].detail.message).toBe(
+                'Error creating Account'
+            );
         });
 
-        it('when there is an error updating a record', () => {
+        it('when there is an error updating a record', async () => {
             // Create initial element
             const element = createElement('c-edit-record', {
                 is: EditRecord
@@ -155,27 +156,25 @@ describe('c-edit-record', () => {
             );
             recordForm.dispatchEvent(new CustomEvent('error'));
 
-            // Return a promise to wait for any asynchronous DOM updates. Jest
-            // will automatically wait for the Promise chain to complete before
-            // ending the test and fail the test if the promise rejects.
-            return Promise.resolve().then(() => {
-                // Check if toast event has been fired
-                expect(handler).toHaveBeenCalled();
-                expect(handler.mock.calls[0][0].detail.variant).toBe('error');
-                expect(handler.mock.calls[0][0].detail.message).toBe(
-                    'Error updating Account'
-                );
-            });
+            // Wait for any asynchronous DOM updates
+            await flushPromises();
+
+            // Check if toast event has been fired
+            expect(handler).toHaveBeenCalled();
+            expect(handler.mock.calls[0][0].detail.variant).toBe('error');
+            expect(handler.mock.calls[0][0].detail.message).toBe(
+                'Error updating Account'
+            );
         });
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-edit-record', {
             is: EditRecord
         });
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/editRecordWrapper/__tests__/editRecordWrapper.test.js
+++ b/force-app/main/default/lwc/editRecordWrapper/__tests__/editRecordWrapper.test.js
@@ -30,13 +30,13 @@ describe('c-edit-record-wrapper', () => {
         expect(innerEl.recordId).toBe(RECORD_ID);
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-edit-record-wrapper', {
             is: EditRecordWrapper
         });
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/editableList/__tests__/editableList.test.js
+++ b/force-app/main/default/lwc/editableList/__tests__/editableList.test.js
@@ -50,7 +50,13 @@ describe('c-editable-list', () => {
         jest.clearAllMocks();
     });
 
-    it('renders lightning-datatable when there is data', () => {
+    // Helper function to wait until the microtask queue is empty.
+    // Used to wait for asynchronous DOM updates.
+    async function flushPromises() {
+        return Promise.resolve();
+    }
+
+    it('renders lightning-datatable when there is data', async () => {
         // Create initial element
         const element = createElement('c-editable-list', {
             is: EditableList
@@ -60,20 +66,18 @@ describe('c-editable-list', () => {
         // Emit data from @wire
         getAccountsAdapter.emit(mockGetAccounts);
 
-        // Return a promise to wait for any asynchronous DOM updates. Jest
-        // will automatically wait for the Promise chain to complete before
-        // ending the test and fail the test if the promise rejects.
-        return Promise.resolve().then(() => {
-            const datatableEl = element.shadowRoot.querySelector(
-                'lightning-datatable'
-            );
-            expect(datatableEl).not.toBeNull();
-            expect(datatableEl.data).toStrictEqual(mockGetAccounts);
-            expect(datatableEl.columns).toStrictEqual(COLUMNS);
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        const datatableEl = element.shadowRoot.querySelector(
+            'lightning-datatable'
+        );
+        expect(datatableEl).not.toBeNull();
+        expect(datatableEl.data).toStrictEqual(mockGetAccounts);
+        expect(datatableEl.columns).toStrictEqual(COLUMNS);
     });
 
-    it('renders error panel when there is error', () => {
+    it('renders error panel when there is error', async () => {
         const APEX_ERROR = {
             body: 'Error retrieving records',
             ok: false,
@@ -94,18 +98,15 @@ describe('c-editable-list', () => {
             APEX_ERROR.statusText
         );
 
-        // Return a promise to wait for any asynchronous DOM updates. Jest
-        // will automatically wait for the Promise chain to complete before
-        // ending the test and fail the test if the promise rejects.
-        return Promise.resolve().then(() => {
-            const errorPanelEl =
-                element.shadowRoot.querySelector('c-error-panel');
-            expect(errorPanelEl).not.toBeNull();
-            expect(errorPanelEl.errors).toStrictEqual(APEX_ERROR);
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        const errorPanelEl = element.shadowRoot.querySelector('c-error-panel');
+        expect(errorPanelEl).not.toBeNull();
+        expect(errorPanelEl.errors).toStrictEqual(APEX_ERROR);
     });
 
-    it('is accessible when data is returned', () => {
+    it('is accessible when data is returned', async () => {
         // Create initial element
         const element = createElement('c-editable-list', {
             is: EditableList
@@ -115,10 +116,13 @@ describe('c-editable-list', () => {
         // Emit data from @wire
         getAccountsAdapter.emit(mockGetAccounts);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        await expect(element).toBeAccessible();
     });
 
-    it('is accessible when error is returned', () => {
+    it('is accessible when error is returned', async () => {
         const APEX_ERROR = {
             body: 'Error retrieving records',
             ok: false,
@@ -139,6 +143,9 @@ describe('c-editable-list', () => {
             APEX_ERROR.statusText
         );
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/editableListWrapper/__tests__/editableListWrapper.test.js
+++ b/force-app/main/default/lwc/editableListWrapper/__tests__/editableListWrapper.test.js
@@ -28,13 +28,13 @@ describe('c-editable-list-wrapper', () => {
         expect(innerEl).not.toBeNull();
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-editable-list-wrapper', {
             is: EditableListWrapper
         });
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/errorPanel/__tests__/errorPanel.test.js
+++ b/force-app/main/default/lwc/errorPanel/__tests__/errorPanel.test.js
@@ -9,6 +9,12 @@ describe('c-error-panel', () => {
         }
     });
 
+    // Helper function to wait until the microtask queue is empty.
+    // Used to wait for asynchronous DOM updates.
+    async function flushPromises() {
+        return Promise.resolve();
+    }
+
     it('displays a default friendly message', () => {
         const MESSAGE = 'Error retrieving data';
 
@@ -47,7 +53,7 @@ describe('c-error-panel', () => {
         expect(inputEl).toBeNull();
     });
 
-    it('displays error details when errors are passed as parameters', () => {
+    it('displays error details when errors are passed as parameters', async () => {
         const ERROR_MESSAGES_INPUT = [
             { statusText: 'First bad error' },
             { statusText: 'Second bad error' }
@@ -65,18 +71,16 @@ describe('c-error-panel', () => {
         inputEl.checked = true;
         inputEl.dispatchEvent(new CustomEvent('click'));
 
-        // Return a promise to wait for any asynchronous DOM updates. Jest
-        // will automatically wait for the Promise chain to complete before
-        // ending the test and fail the test if the promise rejects.
-        return Promise.resolve().then(() => {
-            const messageTexts = Array.from(
-                element.shadowRoot.querySelectorAll('p')
-            ).map((errorMessage) => (errorMessage = errorMessage.textContent));
-            expect(messageTexts).toEqual(ERROR_MESSAGES_OUTPUT);
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        const messageTexts = Array.from(
+            element.shadowRoot.querySelectorAll('p')
+        ).map((errorMessage) => (errorMessage = errorMessage.textContent));
+        expect(messageTexts).toEqual(ERROR_MESSAGES_OUTPUT);
     });
 
-    it('is accessible when inline message', () => {
+    it('is accessible when inline message', async () => {
         const ERROR_MESSAGES_INPUT = [
             { statusText: 'First bad error' },
             { statusText: 'Second bad error' }
@@ -93,10 +97,13 @@ describe('c-error-panel', () => {
         // Click link to show details
         element.shadowRoot.querySelector('a').click();
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        await expect(element).toBeAccessible();
     });
 
-    it('is accessible when no data illustration', () => {
+    it('is accessible when no data illustration', async () => {
         const ERROR_MESSAGES_INPUT = [
             { statusText: 'First bad error' },
             { statusText: 'Second bad error' }
@@ -113,6 +120,9 @@ describe('c-error-panel', () => {
         // Click link to show details
         element.shadowRoot.querySelector('a').click();
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/errorPopover/__tests__/errorPopover.test.js
+++ b/force-app/main/default/lwc/errorPopover/__tests__/errorPopover.test.js
@@ -9,7 +9,13 @@ describe('c-error-popover', () => {
         }
     });
 
-    it('renders c-error-popover element', () => {
+    // Helper function to wait until the microtask queue is empty.
+    // Used to wait for asynchronous DOM updates.
+    async function flushPromises() {
+        return Promise.resolve();
+    }
+
+    it('renders c-error-popover element', async () => {
         const ERROR_MESSAGE_INPUT = 'Friendly Error Message';
 
         const element = createElement('c-error-popover', {
@@ -17,17 +23,18 @@ describe('c-error-popover', () => {
         });
         element.errors = ERROR_MESSAGE_INPUT;
         document.body.appendChild(element);
+
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
 
         // Check for errors in body
-        return Promise.resolve().then(() => {
-            const popoverDivEl = element.shadowRoot.querySelector(
-                '.slds-popover__body'
-            );
-            expect(popoverDivEl.textContent).toBe(ERROR_MESSAGE_INPUT);
-        });
+        const popoverDivEl = element.shadowRoot.querySelector(
+            '.slds-popover__body'
+        );
+        expect(popoverDivEl.textContent).toBe(ERROR_MESSAGE_INPUT);
     });
 
-    it('hides dialog when close button is clicked', () => {
+    it('hides dialog when close button is clicked', async () => {
         const ERROR_MESSAGE_INPUT = 'Friendly Error Message';
 
         const element = createElement('c-error-popover', {
@@ -36,18 +43,18 @@ describe('c-error-popover', () => {
         element.errors = ERROR_MESSAGE_INPUT;
         document.body.appendChild(element);
 
-        // click lightning button element
+        // Click lightning button element
         element.shadowRoot.querySelector('lightning-button-icon').click();
 
-        return Promise.resolve().then(() => {
-            // check that the section is not rendered once close dialog button is clicked.
-            const reRenderedSectionEl =
-                element.shadowRoot.querySelector('section');
-            expect(reRenderedSectionEl).toBeNull();
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        // Check that the section is not rendered once close dialog button is clicked.
+        const reRenderedSectionEl = element.shadowRoot.querySelector('section');
+        expect(reRenderedSectionEl).toBeNull();
     });
 
-    it('toggles c-error-popover', () => {
+    it('toggles c-error-popover', async () => {
         const ERROR_MESSAGE_INPUT = 'Friendly Error Message';
 
         const element = createElement('c-error-popover', {
@@ -58,15 +65,15 @@ describe('c-error-popover', () => {
 
         element.toggle();
 
-        return Promise.resolve().then(() => {
-            // check that the section that previously rendered no more renders once toggled.
-            const reRenderedSectionEl =
-                element.shadowRoot.querySelector('section');
-            expect(reRenderedSectionEl).toBeNull();
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        // Check that the section that previously rendered no more renders once toggled.
+        const reRenderedSectionEl = element.shadowRoot.querySelector('section');
+        expect(reRenderedSectionEl).toBeNull();
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-error-popover', {
             is: ErrorPopover
         });
@@ -74,6 +81,6 @@ describe('c-error-popover', () => {
         element.showPopover = true;
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/exampleWrapper/__tests__/exampleWrapper.test.js
+++ b/force-app/main/default/lwc/exampleWrapper/__tests__/exampleWrapper.test.js
@@ -68,7 +68,7 @@ describe('c-example-wrapper', () => {
         expect(iframeEl.src).toContain(`/apex/${VISUALFORCE}`);
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-example-wrapper', {
             is: ExampleWrapper
         });
@@ -79,6 +79,6 @@ describe('c-example-wrapper', () => {
         const iframeEl = element.shadowRoot.querySelector('iframe');
         iframeEl.remove();
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/listInfiniteScrolling/__tests__/listInfiniteScrolling.test.js
+++ b/force-app/main/default/lwc/listInfiniteScrolling/__tests__/listInfiniteScrolling.test.js
@@ -16,26 +16,33 @@ describe('c-list-infinite-scrolling', () => {
         }
     });
 
-    it('displays a data table when records is true', () => {
+    // Helper function to wait until the microtask queue is empty.
+    // Used to wait for asynchronous DOM updates.
+    async function flushPromises() {
+        return Promise.resolve();
+    }
+
+    it('displays a data table when records is true', async () => {
         const element = createElement('c-list-infinite-scrolling', {
             is: ListInfiniteScrolling
         });
         document.body.appendChild(element);
         getAccountsPaginatedAdapter.emit(mockGetAccountsPaginatedRecords);
 
-        return Promise.resolve().then(() => {
-            const dataTableEl = element.shadowRoot.querySelector(
-                'lightning-datatable'
-            );
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
 
-            expect(dataTableEl).not.toBeNull();
-            expect(dataTableEl.data).toEqual(
-                mockGetAccountsPaginatedRecords.records
-            );
-        });
+        const dataTableEl = element.shadowRoot.querySelector(
+            'lightning-datatable'
+        );
+
+        expect(dataTableEl).not.toBeNull();
+        expect(dataTableEl.data).toEqual(
+            mockGetAccountsPaginatedRecords.records
+        );
     });
 
-    it('displays the error panel when @wire returns error', () => {
+    it('displays the error panel when @wire returns error', async () => {
         const MESSAGE = 'Error with @wire';
         const element = createElement('c-list-infinite-scrolling', {
             is: ListInfiniteScrolling
@@ -43,32 +50,33 @@ describe('c-list-infinite-scrolling', () => {
         document.body.appendChild(element);
         getAccountsPaginatedAdapter.error(MESSAGE);
 
-        return Promise.resolve().then(() => {
-            const errorPanelEl =
-                element.shadowRoot.querySelector('c-error-panel');
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
 
-            expect(errorPanelEl).not.toBeNull();
-            expect(errorPanelEl.errors.body).toBe(MESSAGE);
-        });
+        const errorPanelEl = element.shadowRoot.querySelector('c-error-panel');
+
+        expect(errorPanelEl).not.toBeNull();
+        expect(errorPanelEl.errors.body).toBe(MESSAGE);
     });
 
-    it('does not display a data table when @wire returns error', () => {
+    it('does not display a data table when @wire returns error', async () => {
         const element = createElement('c-list-infinite-scrolling', {
             is: ListInfiniteScrolling
         });
         document.body.appendChild(element);
         getAccountsPaginatedAdapter.error();
 
-        return Promise.resolve().then(() => {
-            const dataTableEl = element.shadowRoot.querySelector(
-                'lightning-datatable'
-            );
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
 
-            expect(dataTableEl).toBeNull();
-        });
+        const dataTableEl = element.shadowRoot.querySelector(
+            'lightning-datatable'
+        );
+
+        expect(dataTableEl).toBeNull();
     });
 
-    it('requests more data when scrolling reaches the bottom', () => {
+    it('requests more data when scrolling reaches the bottom', async () => {
         const element = createElement('c-list-infinite-scrolling', {
             is: ListInfiniteScrolling
         });
@@ -76,34 +84,28 @@ describe('c-list-infinite-scrolling', () => {
 
         getAccountsPaginatedAdapter.emit(mockGetAccountsPaginatedRecords);
 
-        return Promise.resolve()
-            .then(() => {
-                const dataTableEl = element.shadowRoot.querySelector(
-                    'lightning-datatable'
-                );
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
 
-                expect(dataTableEl).not.toBeNull();
-                expect(dataTableEl.data).toEqual(
-                    mockGetAccountsPaginatedRecords.records
-                );
-                expect(
-                    getAccountsPaginatedAdapter.getLastConfig().pageToken
-                ).toBe(0);
-            })
-            .then(() => {
-                const dataTableEl = element.shadowRoot.querySelector(
-                    'lightning-datatable'
-                );
-                dataTableEl.dispatchEvent(new CustomEvent('loadmore'));
-            })
-            .then(() => {
-                expect(
-                    getAccountsPaginatedAdapter.getLastConfig().pageToken
-                ).toBe(5);
-            });
+        const dataTableEl = element.shadowRoot.querySelector(
+            'lightning-datatable'
+        );
+
+        expect(dataTableEl).not.toBeNull();
+        expect(dataTableEl.data).toEqual(
+            mockGetAccountsPaginatedRecords.records
+        );
+        expect(getAccountsPaginatedAdapter.getLastConfig().pageToken).toBe(0);
+
+        dataTableEl.dispatchEvent(new CustomEvent('loadmore'));
+
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        expect(getAccountsPaginatedAdapter.getLastConfig().pageToken).toBe(5);
     });
 
-    it('is accessible when data is returned', () => {
+    it('is accessible when data is returned', async () => {
         const element = createElement('c-list-infinite-scrolling', {
             is: ListInfiniteScrolling
         });
@@ -112,10 +114,13 @@ describe('c-list-infinite-scrolling', () => {
 
         getAccountsPaginatedAdapter.emit(mockGetAccountsPaginatedRecords);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        await expect(element).toBeAccessible();
     });
 
-    it('is accessible when error is returned', () => {
+    it('is accessible when error is returned', async () => {
         const element = createElement('c-list-infinite-scrolling', {
             is: ListInfiniteScrolling
         });
@@ -124,6 +129,9 @@ describe('c-list-infinite-scrolling', () => {
 
         getAccountsPaginatedAdapter.error();
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/listInfiniteScrollingGetListUi/__tests__/listInfiniteScrollingGetListUi.test.js
+++ b/force-app/main/default/lwc/listInfiniteScrollingGetListUi/__tests__/listInfiniteScrollingGetListUi.test.js
@@ -18,7 +18,13 @@ describe('c-list-infinite-scrolling-get-list-ui', () => {
         jest.clearAllMocks();
     });
 
-    it('displays a data table when records is true', () => {
+    // Helper function to wait until the microtask queue is empty.
+    // Used to wait for asynchronous DOM updates.
+    async function flushPromises() {
+        return Promise.resolve();
+    }
+
+    it('displays a data table when records is true', async () => {
         // Create element
         const element = createElement('c-list-infinite-scrolling-get-list-ui', {
             is: ListInfiniteScrollingGetListUi
@@ -28,17 +34,18 @@ describe('c-list-infinite-scrolling-get-list-ui', () => {
         // Mock returned data
         getListUiAdapter.emit(mockGetAccountData);
 
-        return Promise.resolve().then(() => {
-            const dataTableEl = element.shadowRoot.querySelector(
-                'lightning-datatable'
-            );
-            expect(dataTableEl.data).toEqual(
-                formatGetListUiSObjects(mockGetAccountData)
-            );
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        const dataTableEl = element.shadowRoot.querySelector(
+            'lightning-datatable'
+        );
+        expect(dataTableEl.data).toEqual(
+            formatGetListUiSObjects(mockGetAccountData)
+        );
     });
 
-    it('displays an error when the error variable is set', () => {
+    it('displays an error when the error variable is set', async () => {
         const MESSAGE = 'Error retrieving data';
 
         // Create element
@@ -50,43 +57,39 @@ describe('c-list-infinite-scrolling-get-list-ui', () => {
         // Emit error from wire adapter
         getListUiAdapter.error(MESSAGE);
 
-        return Promise.resolve().then(() => {
-            const errorPanelEl =
-                element.shadowRoot.querySelector('c-error-panel');
-            expect(errorPanelEl.errors.body).toBe(MESSAGE);
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        const errorPanelEl = element.shadowRoot.querySelector('c-error-panel');
+        expect(errorPanelEl.errors.body).toBe(MESSAGE);
     });
 
-    it('requests more data when scrolling reaches the bottom', () => {
+    it('requests more data when scrolling reaches the bottom', async () => {
         const element = createElement('c-list-infinite-scrolling-get-list-ui', {
             is: ListInfiniteScrollingGetListUi
         });
         document.body.appendChild(element);
 
-        return Promise.resolve()
-            .then(() => {
-                const dataTableEl = element.shadowRoot.querySelector(
-                    'lightning-datatable'
-                );
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
 
-                expect(dataTableEl).not.toBeNull();
-                expect(getListUiAdapter.getLastConfig().pageToken).toBe(0);
-            })
-            .then(() => {
-                // Run the event load more to simulate scrolling
-                const dataTableEl = element.shadowRoot.querySelector(
-                    'lightning-datatable'
-                );
-                dataTableEl.dispatchEvent(new CustomEvent('loadmore'));
-            })
-            .then(() => {
-                // If the scroll worked, our new pageToken should have updated from
-                // 0 to 5.
-                expect(getListUiAdapter.getLastConfig().pageToken).toBe(5);
-            });
+        const dataTableEl = element.shadowRoot.querySelector(
+            'lightning-datatable'
+        );
+
+        expect(dataTableEl).not.toBeNull();
+        expect(getListUiAdapter.getLastConfig().pageToken).toBe(0);
+
+        dataTableEl.dispatchEvent(new CustomEvent('loadmore'));
+
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+        // If the scroll worked, our new pageToken should have updated from
+        // 0 to 5.
+        expect(getListUiAdapter.getLastConfig().pageToken).toBe(5);
     });
 
-    it('is accessible when data is returned', () => {
+    it('is accessible when data is returned', async () => {
         // Create element
         const element = createElement('c-list-infinite-scrolling-get-list-ui', {
             is: ListInfiniteScrollingGetListUi
@@ -96,10 +99,13 @@ describe('c-list-infinite-scrolling-get-list-ui', () => {
         // Mock returned data
         getListUiAdapter.emit(mockGetAccountData);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        await expect(element).toBeAccessible();
     });
 
-    it('is accessible when error is returned', () => {
+    it('is accessible when error is returned', async () => {
         const MESSAGE = 'Error retrieving data';
 
         // Create element
@@ -111,6 +117,9 @@ describe('c-list-infinite-scrolling-get-list-ui', () => {
         // Emit error from wire adapter
         getListUiAdapter.error(MESSAGE);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/listInfiniteScrollingGetListUiWrapper/__tests__/listInfiniteScrollingGetListUiWrapper.test.js
+++ b/force-app/main/default/lwc/listInfiniteScrollingGetListUiWrapper/__tests__/listInfiniteScrollingGetListUiWrapper.test.js
@@ -30,7 +30,7 @@ describe('c-list-infinite-scrolling-get-list-ui-wrapper', () => {
         expect(innerEl).not.toBeNull();
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement(
             'c-list-infinite-scrolling-get-list-ui-wrapper',
             {
@@ -40,6 +40,6 @@ describe('c-list-infinite-scrolling-get-list-ui-wrapper', () => {
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/listInfiniteScrollingWrapper/__tests__/listInfiniteScrollingWrapper.test.js
+++ b/force-app/main/default/lwc/listInfiniteScrollingWrapper/__tests__/listInfiniteScrollingWrapper.test.js
@@ -25,13 +25,13 @@ describe('c-list-infinite-scrolling-wrapper', () => {
         expect(innerEl).not.toBeNull();
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-list-infinite-scrolling-wrapper', {
             is: ListInfiniteScrollingWrapper
         });
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/listRecordLinks/__tests__/listRecordLinks.test.js
+++ b/force-app/main/default/lwc/listRecordLinks/__tests__/listRecordLinks.test.js
@@ -46,7 +46,13 @@ describe('c-list-record-links', () => {
         jest.clearAllMocks();
     });
 
-    it('renders c-datatable-with-custom-types when there is data', () => {
+    // Helper function to wait until the microtask queue is empty.
+    // Used to wait for asynchronous DOM updates.
+    async function flushPromises() {
+        return Promise.resolve();
+    }
+
+    it('renders c-datatable-with-custom-types when there is data', async () => {
         // Create initial element
         const element = createElement('c-list-record-links', {
             is: ListRecordLinks
@@ -56,20 +62,18 @@ describe('c-list-record-links', () => {
         // Emit data from @wire
         getAccountsAdapter.emit(mockGetAccounts);
 
-        // Return a promise to wait for any asynchronous DOM updates. Jest
-        // will automatically wait for the Promise chain to complete before
-        // ending the test and fail the test if the promise rejects.
-        return Promise.resolve().then(() => {
-            const datatableEl = element.shadowRoot.querySelector(
-                'c-datatable-with-custom-types'
-            );
-            expect(datatableEl).not.toBeNull();
-            expect(datatableEl.data).toStrictEqual(mockGetAccounts);
-            expect(datatableEl.columns).toStrictEqual(COLUMNS);
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        const datatableEl = element.shadowRoot.querySelector(
+            'c-datatable-with-custom-types'
+        );
+        expect(datatableEl).not.toBeNull();
+        expect(datatableEl.data).toStrictEqual(mockGetAccounts);
+        expect(datatableEl.columns).toStrictEqual(COLUMNS);
     });
 
-    it('renders error panel when there is error', () => {
+    it('renders error panel when there is error', async () => {
         const APEX_ERROR = {
             body: 'Error retrieving records',
             ok: false,
@@ -90,18 +94,15 @@ describe('c-list-record-links', () => {
             APEX_ERROR.statusText
         );
 
-        // Return a promise to wait for any asynchronous DOM updates. Jest
-        // will automatically wait for the Promise chain to complete before
-        // ending the test and fail the test if the promise rejects.
-        return Promise.resolve().then(() => {
-            const errorPanelEl =
-                element.shadowRoot.querySelector('c-error-panel');
-            expect(errorPanelEl).not.toBeNull();
-            expect(errorPanelEl.errors).toStrictEqual(APEX_ERROR);
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        const errorPanelEl = element.shadowRoot.querySelector('c-error-panel');
+        expect(errorPanelEl).not.toBeNull();
+        expect(errorPanelEl.errors).toStrictEqual(APEX_ERROR);
     });
 
-    it('is accessible when data is returned', () => {
+    it('is accessible when data is returned', async () => {
         // Create initial element
         const element = createElement('c-list-record-links', {
             is: ListRecordLinks
@@ -111,10 +112,13 @@ describe('c-list-record-links', () => {
         // Emit data from @wire
         getAccountsAdapter.emit(mockGetAccounts);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        await expect(element).toBeAccessible();
     });
 
-    it('is accessible when error is returned', () => {
+    it('is accessible when error is returned', async () => {
         const APEX_ERROR = {
             body: 'Error retrieving records',
             ok: false,
@@ -135,6 +139,9 @@ describe('c-list-record-links', () => {
             APEX_ERROR.statusText
         );
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/listRecordLinksWrapper/__tests__/listRecordLinksWrapper.test.js
+++ b/force-app/main/default/lwc/listRecordLinksWrapper/__tests__/listRecordLinksWrapper.test.js
@@ -27,13 +27,13 @@ describe('c-list-record-links-wrapper', () => {
         expect(innerEl).not.toBeNull();
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-list-record-links-wrapper', {
             is: ListRecordLinksWrapper
         });
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/listWithParentRecordData/__tests__/listWithParentRecordData.test.js
+++ b/force-app/main/default/lwc/listWithParentRecordData/__tests__/listWithParentRecordData.test.js
@@ -43,7 +43,13 @@ describe('c-list-with-parent-record-data', () => {
         jest.clearAllMocks();
     });
 
-    it('renders lightning-datatable with parent record fields formatted when there is data', () => {
+    // Helper function to wait until the microtask queue is empty.
+    // Used to wait for asynchronous DOM updates.
+    async function flushPromises() {
+        return Promise.resolve();
+    }
+
+    it('renders lightning-datatable with parent record fields formatted when there is data', async () => {
         // Create initial element
         const element = createElement('c-list-with-parent-record-data', {
             is: ListWithParentRecordData
@@ -53,22 +59,20 @@ describe('c-list-with-parent-record-data', () => {
         // Emit data from @wire
         getAccountsAdapter.emit(mockGetAccounts);
 
-        // Return a promise to wait for any asynchronous DOM updates. Jest
-        // will automatically wait for the Promise chain to complete before
-        // ending the test and fail the test if the promise rejects.
-        return Promise.resolve().then(() => {
-            const datatableEl = element.shadowRoot.querySelector(
-                'lightning-datatable'
-            );
-            expect(datatableEl).not.toBeNull();
-            expect(datatableEl.data).toStrictEqual(
-                formatApexSObjects(mockGetAccounts)
-            );
-            expect(datatableEl.columns).toStrictEqual(COLUMNS);
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        const datatableEl = element.shadowRoot.querySelector(
+            'lightning-datatable'
+        );
+        expect(datatableEl).not.toBeNull();
+        expect(datatableEl.data).toStrictEqual(
+            formatApexSObjects(mockGetAccounts)
+        );
+        expect(datatableEl.columns).toStrictEqual(COLUMNS);
     });
 
-    it('renders error panel when there is error', () => {
+    it('renders error panel when there is error', async () => {
         const APEX_ERROR = {
             body: 'Error retrieving records',
             ok: false,
@@ -89,18 +93,15 @@ describe('c-list-with-parent-record-data', () => {
             APEX_ERROR.statusText
         );
 
-        // Return a promise to wait for any asynchronous DOM updates. Jest
-        // will automatically wait for the Promise chain to complete before
-        // ending the test and fail the test if the promise rejects.
-        return Promise.resolve().then(() => {
-            const errorPanelEl =
-                element.shadowRoot.querySelector('c-error-panel');
-            expect(errorPanelEl).not.toBeNull();
-            expect(errorPanelEl.errors).toStrictEqual(APEX_ERROR);
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        const errorPanelEl = element.shadowRoot.querySelector('c-error-panel');
+        expect(errorPanelEl).not.toBeNull();
+        expect(errorPanelEl.errors).toStrictEqual(APEX_ERROR);
     });
 
-    it('is accessible when data is returned', () => {
+    it('is accessible when data is returned', async () => {
         // Create initial element
         const element = createElement('c-list-with-parent-record-data', {
             is: ListWithParentRecordData
@@ -110,10 +111,13 @@ describe('c-list-with-parent-record-data', () => {
         // Emit data from @wire
         getAccountsAdapter.emit(mockGetAccounts);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        await expect(element).toBeAccessible();
     });
 
-    it('is accessible when error is returned', () => {
+    it('is accessible when error is returned', async () => {
         const APEX_ERROR = {
             body: 'Error retrieving records',
             ok: false,
@@ -134,6 +138,9 @@ describe('c-list-with-parent-record-data', () => {
             APEX_ERROR.statusText
         );
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/listWithParentRecordDataWrapper/__tests__/listWithParentRecordDataWrapper.test.js
+++ b/force-app/main/default/lwc/listWithParentRecordDataWrapper/__tests__/listWithParentRecordDataWrapper.test.js
@@ -32,7 +32,7 @@ describe('c-list-with-parent-record-data-wrapper', () => {
         expect(innerEl).not.toBeNull();
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement(
             'c-list-with-parent-record-data-wrapper',
             {
@@ -42,6 +42,6 @@ describe('c-list-with-parent-record-data-wrapper', () => {
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/navigateToRecord/__tests__/navigateToRecord.test.js
+++ b/force-app/main/default/lwc/navigateToRecord/__tests__/navigateToRecord.test.js
@@ -10,7 +10,13 @@ describe('c-navigate-to-record', () => {
         }
     });
 
-    it('navigates to record view by ID', () => {
+    // Helper function to wait until the microtask queue is empty.
+    // Used to wait for asynchronous DOM updates.
+    async function flushPromises() {
+        return Promise.resolve();
+    }
+
+    it('navigates to record view by ID', async () => {
         const element = createElement('c-navigate-to-record', {
             is: NavigateToRecord
         });
@@ -18,36 +24,38 @@ describe('c-navigate-to-record', () => {
         element.recordId = '0031700000pJRRTAA4';
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => {
-            // Get handle to anchor and fire click event
-            const anchorEl = element.shadowRoot.querySelector('a');
-            expect(anchorEl).not.toBeNull();
-            anchorEl.click();
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
 
-            const { pageReference } = getNavigateCalledWith();
+        // Get handle to anchor and fire click event
+        const anchorEl = element.shadowRoot.querySelector('a');
+        expect(anchorEl).not.toBeNull();
+        anchorEl.click();
 
-            expect(pageReference.type).toEqual('standard__recordPage');
-            expect(pageReference.attributes.recordId).toEqual(element.recordId);
-            expect(pageReference.attributes.actionName).toEqual('view');
-        });
+        const { pageReference } = getNavigateCalledWith();
+
+        expect(pageReference.type).toEqual('standard__recordPage');
+        expect(pageReference.attributes.recordId).toEqual(element.recordId);
+        expect(pageReference.attributes.actionName).toEqual('view');
     });
 
-    it('creates an anchor element with the right label', () => {
+    it('creates an anchor element with the right label', async () => {
         const element = createElement('c-navigate-to-record', {
             is: NavigateToRecord
         });
         element.label = 'foo';
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => {
-            // Get handle to anchor and fire click event
-            const anchorEl = element.shadowRoot.querySelector('a');
-            expect(anchorEl).not.toBeNull();
-            expect(anchorEl.textContent).toEqual(element.label);
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        // Get handle to anchor and fire click event
+        const anchorEl = element.shadowRoot.querySelector('a');
+        expect(anchorEl).not.toBeNull();
+        expect(anchorEl.textContent).toEqual(element.label);
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-navigate-to-record', {
             is: NavigateToRecord
         });
@@ -56,6 +64,6 @@ describe('c-navigate-to-record', () => {
         element.recordId = '0031700000pJRRTAA4';
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/pageBlocks/__tests__/pageBlocks.test.js
+++ b/force-app/main/default/lwc/pageBlocks/__tests__/pageBlocks.test.js
@@ -8,27 +8,35 @@ describe('c-page-block', () => {
             document.body.removeChild(document.body.firstChild);
         }
     });
-    it('displays lightning-accordion-sections A and B', () => {
+
+    // Helper function to wait until the microtask queue is empty.
+    // Used to wait for asynchronous DOM updates.
+    async function flushPromises() {
+        return Promise.resolve();
+    }
+
+    it('displays lightning-accordion-sections A and B', async () => {
         const element = createElement('c-page-blocks', {
             is: PageBlocks
         });
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => {
-            const accordionEl = element.shadowRoot.querySelector(
-                'lightning-accordion'
-            );
-            expect(accordionEl).not.toBeNull();
-            expect(accordionEl.activeSectionName).toStrictEqual(['A', 'B']);
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        const accordionEl = element.shadowRoot.querySelector(
+            'lightning-accordion'
+        );
+        expect(accordionEl).not.toBeNull();
+        expect(accordionEl.activeSectionName).toStrictEqual(['A', 'B']);
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-page-blocks', {
             is: PageBlocks
         });
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/pageBlocksWrapper/__tests__/pageBlocksWrapper.test.js
+++ b/force-app/main/default/lwc/pageBlocksWrapper/__tests__/pageBlocksWrapper.test.js
@@ -26,13 +26,13 @@ describe('c-page-blocks-wrapper', () => {
         expect(innerEl).not.toBeNull();
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-page-blocks-wrapper', {
             is: PageBlocksWrapper
         });
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/pageMessagesDataRetrieval/__tests__/pageMessagesDataRetrieval.test.js
+++ b/force-app/main/default/lwc/pageMessagesDataRetrieval/__tests__/pageMessagesDataRetrieval.test.js
@@ -13,59 +13,76 @@ describe('c-page-messages-data-retrieval', () => {
         }
     });
 
-    it('displays the account.errors in an error panel when accounts.error is true', () => {
+    // Helper function to wait until the microtask queue is empty.
+    // Used to wait for asynchronous DOM updates.
+    async function flushPromises() {
+        return Promise.resolve();
+    }
+
+    it('displays the account.errors in an error panel when accounts.error is true', async () => {
         const element = createElement('c-page-messages-data-retrieval', {
             is: PageMessagesDataRetrieval
         });
-        document.body.appendChild(element);
-        getAccountsAdapter.error('Error Message');
-        return Promise.resolve().then(() => {
-            const errorPanelEl =
-                element.shadowRoot.querySelector('c-error-panel');
-            expect(errorPanelEl).not.toBeNull();
-            expect(errorPanelEl.errors).toStrictEqual({
-                body: 'Error Message',
-                ok: false,
-                status: 400,
-                statusText: 'Bad Request'
-            });
-        });
-    });
-
-    it('displays the account.data in a sub-template when accounts.data is true', () => {
-        const element = createElement('c-page-messages-data-retrieval', {
-            is: PageMessagesDataRetrieval
-        });
-        document.body.appendChild(element);
-        getAccountsAdapter.emit({ data: 'hello world' });
-        return Promise.resolve().then(() => {
-            const paragraphEl = element.shadowRoot.querySelector('p');
-            expect(paragraphEl).not.toBeNull();
-            expect(paragraphEl.textContent).not.toBeNull();
-        });
-    });
-
-    it('is accessible when data is returned', () => {
-        const element = createElement('c-page-messages-data-retrieval', {
-            is: PageMessagesDataRetrieval
-        });
-
-        document.body.appendChild(element);
-
-        getAccountsAdapter.emit({ data: 'hello world' });
-
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
-    });
-
-    it('is accessible when error is returned', () => {
-        const element = createElement('c-page-messages-data-retrieval', {
-            is: PageMessagesDataRetrieval
-        });
-
         document.body.appendChild(element);
 
         getAccountsAdapter.error('Error Message');
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        const errorPanelEl = element.shadowRoot.querySelector('c-error-panel');
+        expect(errorPanelEl).not.toBeNull();
+        expect(errorPanelEl.errors).toStrictEqual({
+            body: 'Error Message',
+            ok: false,
+            status: 400,
+            statusText: 'Bad Request'
+        });
+    });
+
+    it('displays the account.data in a sub-template when accounts.data is true', async () => {
+        const element = createElement('c-page-messages-data-retrieval', {
+            is: PageMessagesDataRetrieval
+        });
+        document.body.appendChild(element);
+
+        getAccountsAdapter.emit({ data: 'hello world' });
+
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        const paragraphEl = element.shadowRoot.querySelector('p');
+        expect(paragraphEl).not.toBeNull();
+        expect(paragraphEl.textContent).not.toBeNull();
+    });
+
+    it('is accessible when data is returned', async () => {
+        const element = createElement('c-page-messages-data-retrieval', {
+            is: PageMessagesDataRetrieval
+        });
+
+        document.body.appendChild(element);
+
+        getAccountsAdapter.emit({ data: 'hello world' });
+
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        await expect(element).toBeAccessible();
+    });
+
+    it('is accessible when error is returned', async () => {
+        const element = createElement('c-page-messages-data-retrieval', {
+            is: PageMessagesDataRetrieval
+        });
+
+        document.body.appendChild(element);
+
+        getAccountsAdapter.error('Error Message');
+
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/pageMessagesDataRetrievalWrapper/__tests__/pageMessagesDataRetrievalWrapper.test.js
+++ b/force-app/main/default/lwc/pageMessagesDataRetrievalWrapper/__tests__/pageMessagesDataRetrievalWrapper.test.js
@@ -32,7 +32,7 @@ describe('c-page-messages-data-retrieval-wrapper', () => {
         expect(innerEl).not.toBeNull();
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement(
             'c-page-message-data-messages-retrieval-wrapper',
             {
@@ -42,6 +42,6 @@ describe('c-page-messages-data-retrieval-wrapper', () => {
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/pageMessagesForm/__tests__/pageMessagesForm.test.js
+++ b/force-app/main/default/lwc/pageMessagesForm/__tests__/pageMessagesForm.test.js
@@ -26,14 +26,13 @@ describe('c-page-messages-form', () => {
         jest.clearAllMocks();
     });
 
-    // Helper function to wait until the microtask queue is empty. This is needed for promise
-    // timing when calling imperative Apex.
-    function flushPromises() {
-        // eslint-disable-next-line no-undef
-        return new Promise((resolve) => setImmediate(resolve));
+    // Helper function to wait until the microtask queue is empty.
+    // Used to wait for asynchronous DOM updates.
+    async function flushPromises() {
+        return Promise.resolve();
     }
 
-    it('displays no error by default', () => {
+    it('displays no error by default', async () => {
         // Create initial element
         const element = createElement('c-page-messages-form', {
             is: PageMessagesForm
@@ -45,7 +44,7 @@ describe('c-page-messages-form', () => {
         expect(listEl).toBeNull();
     });
 
-    it('updates city name when input changes', () => {
+    it('updates city name when input changes', async () => {
         // Create initial element
         const element = createElement('c-page-messages-form', {
             is: PageMessagesForm
@@ -58,15 +57,13 @@ describe('c-page-messages-form', () => {
             new CustomEvent('change', { detail: { value: MOCK_CITY_NAME } })
         );
 
-        // Return a promise to wait for any asynchronous DOM updates. Jest
-        // will automatically wait for the Promise chain to complete before
-        // ending the test and fail the test if the promise rejects.
-        return Promise.resolve().then(() => {
-            expect(inputEl.value).toBe(MOCK_CITY_NAME);
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        expect(inputEl.value).toBe(MOCK_CITY_NAME);
     });
 
-    it('clears city name when cancel button clicked', () => {
+    it('clears city name when cancel button clicked', async () => {
         // Create initial element
         const element = createElement('c-page-messages-form', {
             is: PageMessagesForm
@@ -80,16 +77,14 @@ describe('c-page-messages-form', () => {
         // Click the cancel button
         element.shadowRoot.querySelector('.cancel').click();
 
-        // Return a promise to wait for any asynchronous DOM updates. Jest
-        // will automatically wait for the Promise chain to complete before
-        // ending the test and fail the test if the promise rejects.
-        return Promise.resolve().then(() => {
-            expect(inputEl.value).toBe('');
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        expect(inputEl.value).toBe('');
     });
 
     describe('createCity Apex calls', () => {
-        it('creates city when save button clicked', () => {
+        it('creates city when save button clicked', async () => {
             // Create initial element
             const element = createElement('c-page-messages-form', {
                 is: PageMessagesForm
@@ -105,24 +100,22 @@ describe('c-page-messages-form', () => {
             // Mock create city Apex call result
             createCity.mockResolvedValue(null);
 
-            // Return an immediate flushed promise (after the Apex call) to then
-            // wait for any asynchronous DOM updates. Jest will automatically wait
-            // for the Promise chain to complete before ending the test and fail
-            // the test if the promise ends in the rejected state.
-            return Promise.resolve()
-                .then(() => {
-                    // Click the save button
-                    element.shadowRoot.querySelector('.save').click();
-                })
-                .then(() => {
-                    // Validate parameters of mocked Apex call
-                    expect(createCity).toHaveBeenCalledWith({
-                        cityName: MOCK_CITY_NAME
-                    });
-                });
+            // Wait for any asynchronous DOM updates
+            await flushPromises();
+
+            // Click the save button
+            element.shadowRoot.querySelector('.save').click();
+
+            // Wait for any asynchronous DOM updates
+            await flushPromises();
+
+            // Validate parameters of mocked Apex call
+            expect(createCity).toHaveBeenCalledWith({
+                cityName: MOCK_CITY_NAME
+            });
         });
 
-        it('displays errors when create city fails', () => {
+        it('displays errors when create city fails', async () => {
             // Create initial element
             const element = createElement('c-page-messages-form', {
                 is: PageMessagesForm
@@ -132,33 +125,28 @@ describe('c-page-messages-form', () => {
             // Mock create city Apex error
             createCity.mockRejectedValue(MOCK_ERROR);
 
-            // Return an immediate flushed promise (after the Apex call) to then
-            // wait for any asynchronous DOM updates. Jest will automatically wait
-            // for the Promise chain to complete before ending the test and fail
-            // the test if the promise ends in the rejected state.
-            return flushPromises()
-                .then(() => {
-                    // Click the save button
-                    element.shadowRoot.querySelector('.save').click();
-                })
-                .then(() => {
-                    // Wait Apex call to resolve and for rerender
-                    return flushPromises();
-                })
-                .then(() => {
-                    // Validate that error is showing up
-                    const errorButtonIconEl = element.shadowRoot.querySelector(
-                        'lightning-button-icon'
-                    );
-                    expect(errorButtonIconEl).not.toBeNull();
-                    const errorPopoverEl =
-                        element.shadowRoot.querySelector('c-error-popover');
-                    expect(errorPopoverEl).not.toBeNull();
-                });
+            // Wait for any asynchronous DOM updates
+            await flushPromises();
+
+            // Click the save button
+            element.shadowRoot.querySelector('.save').click();
+
+            // Wait for any asynchronous DOM updates
+            await flushPromises();
+
+            // Validate that error is showing up
+            const errorButtonIconEl = element.shadowRoot.querySelector(
+                'lightning-button-icon'
+            );
+            expect(errorButtonIconEl).not.toBeNull();
+
+            const errorPopoverEl =
+                element.shadowRoot.querySelector('c-error-popover');
+            expect(errorPopoverEl).not.toBeNull();
         });
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         // Create initial element
         const element = createElement('c-page-messages-form', {
             is: PageMessagesForm
@@ -168,6 +156,9 @@ describe('c-page-messages-form', () => {
         // Mock create city Apex error
         createCity.mockRejectedValue(MOCK_ERROR);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/pageMessagesFormWrapper/__tests__/pageMessagesFormWrapper.test.js
+++ b/force-app/main/default/lwc/pageMessagesFormWrapper/__tests__/pageMessagesFormWrapper.test.js
@@ -26,13 +26,13 @@ describe('c-page-messages-form-wrapper', () => {
         expect(innerEl).not.toBeNull();
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-page-messages-form-wrapper', {
             is: PageMessagesFormWrapper
         });
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/pageMessagesToast/__tests__/pageMessagesToast.test.js
+++ b/force-app/main/default/lwc/pageMessagesToast/__tests__/pageMessagesToast.test.js
@@ -25,8 +25,8 @@ describe('c-page-messages-toast', () => {
         jest.clearAllMocks();
     });
 
-    // Helper function to wait until the microtask queue is empty. This is needed for promise
-    // timing when calling imperative Apex.
+    // Helper function to wait until the microtask queue is empty.
+    // Used to wait for asynchronous DOM updates.
     function flushPromises() {
         // eslint-disable-next-line no-undef
         return new Promise((resolve) => setImmediate(resolve));
@@ -89,13 +89,13 @@ describe('c-page-messages-toast', () => {
         });
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-page-messages-toast', {
             is: PageMessagesToast
         });
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/pageMessagesToastWrapper/__tests__/pageMessagesToastWrapper.test.js
+++ b/force-app/main/default/lwc/pageMessagesToastWrapper/__tests__/pageMessagesToastWrapper.test.js
@@ -26,13 +26,13 @@ describe('c-page-messages-toast-wrapper', () => {
         expect(innerEl).not.toBeNull();
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-page-messages-toast-wrapper', {
             is: PageMessagesToastWrapper
         });
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/paginatedList/__tests__/paginatedList.test.js
+++ b/force-app/main/default/lwc/paginatedList/__tests__/paginatedList.test.js
@@ -37,7 +37,13 @@ describe('c-paginated-list', () => {
         jest.clearAllMocks();
     });
 
-    it('renders table with records fetched from wire', () => {
+    // Helper function to wait until the microtask queue is empty.
+    // Used to wait for asynchronous DOM updates.
+    async function flushPromises() {
+        return Promise.resolve();
+    }
+
+    it('renders table with records fetched from wire', async () => {
         // Create initial element
         const element = createElement('c-paginated-list', {
             is: PaginatedList
@@ -47,21 +53,19 @@ describe('c-paginated-list', () => {
         // Emit mock data
         getAccountsPaginatedAdapter.emit(mockGetAccountData);
 
-        // Return a promise to wait for any asynchronous DOM updates. Jest
-        // will automatically wait for the Promise chain to complete before
-        // ending the test and fail the test if the promise rejects.
-        return Promise.resolve().then(() => {
-            // Check that datatable contains the right data
-            const datatableEl = element.shadowRoot.querySelector(
-                'lightning-datatable'
-            );
-            expect(datatableEl).not.toBeNull();
-            expect(datatableEl.data).toStrictEqual(mockGetAccountData.records);
-            expect(datatableEl.columns).toStrictEqual(COLUMNS);
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        // Check that datatable contains the right data
+        const datatableEl = element.shadowRoot.querySelector(
+            'lightning-datatable'
+        );
+        expect(datatableEl).not.toBeNull();
+        expect(datatableEl.data).toStrictEqual(mockGetAccountData.records);
+        expect(datatableEl.columns).toStrictEqual(COLUMNS);
     });
 
-    it('disables next button on last page', () => {
+    it('disables next button on last page', async () => {
         // Create initial element
         const element = createElement('c-paginated-list', {
             is: PaginatedList
@@ -72,17 +76,15 @@ describe('c-paginated-list', () => {
         delete mockGetAccountData.nextPageToken;
         getAccountsPaginatedAdapter.emit(mockGetAccountData);
 
-        // Return a promise to wait for any asynchronous DOM updates. Jest
-        // will automatically wait for the Promise chain to complete before
-        // ending the test and fail the test if the promise rejects.
-        return Promise.resolve().then(() => {
-            // Check that datatable contains the right data
-            const paginatorEl = element.shadowRoot.querySelector('c-paginator');
-            expect(paginatorEl.nextButtonDisabled).toBeTruthy();
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        // Check that datatable contains the right data
+        const paginatorEl = element.shadowRoot.querySelector('c-paginator');
+        expect(paginatorEl.nextButtonDisabled).toBeTruthy();
     });
 
-    it('disables previous button on first page', () => {
+    it('disables previous button on first page', async () => {
         // Create initial element
         const element = createElement('c-paginated-list', {
             is: PaginatedList
@@ -92,17 +94,15 @@ describe('c-paginated-list', () => {
         // Emit mock data
         getAccountsPaginatedAdapter.emit(mockGetAccountData);
 
-        // Return a promise to wait for any asynchronous DOM updates. Jest
-        // will automatically wait for the Promise chain to complete before
-        // ending the test and fail the test if the promise rejects.
-        return Promise.resolve().then(() => {
-            // Check that datatable contains the right data
-            const paginatorEl = element.shadowRoot.querySelector('c-paginator');
-            expect(paginatorEl.previousButtonDisabled).toBeTruthy();
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        // Check that datatable contains the right data
+        const paginatorEl = element.shadowRoot.querySelector('c-paginator');
+        expect(paginatorEl.previousButtonDisabled).toBeTruthy();
     });
 
-    it('requests next page when next button is clicked', () => {
+    it('requests next page when next button is clicked', async () => {
         const NEXT_PAGE_TOKEN = 5;
 
         // Create initial element
@@ -115,25 +115,23 @@ describe('c-paginated-list', () => {
         mockGetAccountData.nextPageToken = NEXT_PAGE_TOKEN;
         getAccountsPaginatedAdapter.emit(mockGetAccountData);
 
-        // Return a promise to wait for any asynchronous DOM updates. Jest
-        // will automatically wait for the Promise chain to complete before
-        // ending the test and fail the test if the promise rejects.
-        return Promise.resolve()
-            .then(() => {
-                // Request next page
-                const paginatorEl =
-                    element.shadowRoot.querySelector('c-paginator');
-                paginatorEl.dispatchEvent(new CustomEvent('next'));
-            })
-            .then(() => {
-                // Check that wire was called to retrieve next page
-                expect(
-                    getAccountsPaginatedAdapter.getLastConfig().pageToken
-                ).toBe(NEXT_PAGE_TOKEN);
-            });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        // Request next page
+        const paginatorEl = element.shadowRoot.querySelector('c-paginator');
+        paginatorEl.dispatchEvent(new CustomEvent('next'));
+
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        // Check that wire was called to retrieve next page
+        expect(getAccountsPaginatedAdapter.getLastConfig().pageToken).toBe(
+            NEXT_PAGE_TOKEN
+        );
     });
 
-    it('requests previous page when previous button is clicked', () => {
+    it('requests previous page when previous button is clicked', async () => {
         // Create initial element
         const element = createElement('c-paginated-list', {
             is: PaginatedList
@@ -143,25 +141,21 @@ describe('c-paginated-list', () => {
         // Emit mock data
         getAccountsPaginatedAdapter.emit(mockGetAccountData);
 
-        // Return a promise to wait for any asynchronous DOM updates. Jest
-        // will automatically wait for the Promise chain to complete before
-        // ending the test and fail the test if the promise rejects.
-        return Promise.resolve()
-            .then(() => {
-                // Request previous page
-                const paginatorEl =
-                    element.shadowRoot.querySelector('c-paginator');
-                paginatorEl.dispatchEvent(new CustomEvent('previous'));
-            })
-            .then(() => {
-                // Check that wire was called to retrieve previous page
-                expect(
-                    getAccountsPaginatedAdapter.getLastConfig().pageToken
-                ).toBe(-5);
-            });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        // Request previous page
+        const paginatorEl = element.shadowRoot.querySelector('c-paginator');
+        paginatorEl.dispatchEvent(new CustomEvent('previous'));
+
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        // Check that wire was called to retrieve previous page
+        expect(getAccountsPaginatedAdapter.getLastConfig().pageToken).toBe(-5);
     });
 
-    it('renders error panel when wire emits error', () => {
+    it('renders error panel when wire emits error', async () => {
         const ERROR = { message: 'An error message' };
 
         // Create initial element
@@ -173,18 +167,15 @@ describe('c-paginated-list', () => {
         // Emit error from @wire
         getAccountsPaginatedAdapter.error(ERROR);
 
-        // Return a promise to wait for any asynchronous DOM updates. Jest
-        // will automatically wait for the Promise chain to complete before
-        // ending the test and fail the test if the promise rejects.
-        return Promise.resolve().then(() => {
-            const errorPanelEl =
-                element.shadowRoot.querySelector('c-error-panel');
-            expect(errorPanelEl).not.toBeNull();
-            expect(errorPanelEl.errors.body).toStrictEqual(ERROR);
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        const errorPanelEl = element.shadowRoot.querySelector('c-error-panel');
+        expect(errorPanelEl).not.toBeNull();
+        expect(errorPanelEl.errors.body).toStrictEqual(ERROR);
     });
 
-    it('is accessible when data is returned', () => {
+    it('is accessible when data is returned', async () => {
         // Create initial element
         const element = createElement('c-paginated-list', {
             is: PaginatedList
@@ -194,10 +185,13 @@ describe('c-paginated-list', () => {
         // Emit mock data
         getAccountsPaginatedAdapter.emit(mockGetAccountData);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        await expect(element).toBeAccessible();
     });
 
-    it('is accessible when error is returned', () => {
+    it('is accessible when error is returned', async () => {
         const ERROR = { message: 'An error message' };
 
         // Create initial element
@@ -209,6 +203,9 @@ describe('c-paginated-list', () => {
         // Emit error from @wire
         getAccountsPaginatedAdapter.error(ERROR);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/paginatedListWrapper/__tests__/paginatedListWrapper.test.js
+++ b/force-app/main/default/lwc/paginatedListWrapper/__tests__/paginatedListWrapper.test.js
@@ -26,13 +26,13 @@ describe('c-page-messages-toast-wrapper', () => {
         expect(innerEl).not.toBeNull();
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-paginated-list-wrapper', {
             is: PaginatedListWrapper
         });
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/paginator/__tests__/paginator.test.js
+++ b/force-app/main/default/lwc/paginator/__tests__/paginator.test.js
@@ -9,7 +9,13 @@ describe('c-paginator', () => {
         }
     });
 
-    it('sends "next" event on button click', () => {
+    // Helper function to wait until the microtask queue is empty.
+    // Used to wait for asynchronous DOM updates.
+    async function flushPromises() {
+        return Promise.resolve();
+    }
+
+    it('sends "next" event on button click', async () => {
         // Create initial element
         const element = createElement('c-paginator', {
             is: Paginator
@@ -27,16 +33,14 @@ describe('c-paginator', () => {
         expect(nextButtonEl.disabled).toBeFalsy();
         nextButtonEl.click();
 
-        // Return a promise to wait for any asynchronous DOM updates. Jest
-        // will automatically wait for the Promise chain to complete before
-        // ending the test and fail the test if the promise rejects.
-        return Promise.resolve().then(() => {
-            // Validate if mocked events got fired
-            expect(handlerNext.mock.calls.length).toBe(1);
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        // Validate if mocked events got fired
+        expect(handlerNext.mock.calls.length).toBe(1);
     });
 
-    it('sends "previous" event on button click', () => {
+    it('sends "previous" event on button click', async () => {
         // Create initial element
         const element = createElement('c-paginator', {
             is: Paginator
@@ -54,16 +58,14 @@ describe('c-paginator', () => {
         expect(prevButtonEl.disabled).toBeFalsy();
         prevButtonEl.click();
 
-        // Return a promise to wait for any asynchronous DOM updates. Jest
-        // will automatically wait for the Promise chain to complete before
-        // ending the test and fail the test if the promise rejects.
-        return Promise.resolve().then(() => {
-            // Validate if mocked events got fired
-            expect(handlerPrevious.mock.calls.length).toBe(1);
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        // Validate if mocked events got fired
+        expect(handlerPrevious.mock.calls.length).toBe(1);
     });
 
-    it('disables "next" button when attribute is set', () => {
+    it('disables "next" button when attribute is set', async () => {
         // Create initial element
         const element = createElement('c-paginator', {
             is: Paginator
@@ -71,17 +73,15 @@ describe('c-paginator', () => {
         element.nextButtonDisabled = true;
         document.body.appendChild(element);
 
-        // Return a promise to wait for any asynchronous DOM updates. Jest
-        // will automatically wait for the Promise chain to complete before
-        // ending the test and fail the test if the promise rejects.
-        return Promise.resolve().then(() => {
-            // Next button should be disabled
-            const nextButtonEl = element.shadowRoot.querySelector('.next');
-            expect(nextButtonEl.disabled).toBeTruthy();
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        // Next button should be disabled
+        const nextButtonEl = element.shadowRoot.querySelector('.next');
+        expect(nextButtonEl.disabled).toBeTruthy();
     });
 
-    it('disables "previous" button when attribute is set', () => {
+    it('disables "previous" button when attribute is set', async () => {
         // Create initial element
         const element = createElement('c-paginator', {
             is: Paginator
@@ -89,23 +89,21 @@ describe('c-paginator', () => {
         element.previousButtonDisabled = true;
         document.body.appendChild(element);
 
-        // Return a promise to wait for any asynchronous DOM updates. Jest
-        // will automatically wait for the Promise chain to complete before
-        // ending the test and fail the test if the promise rejects.
-        return Promise.resolve().then(() => {
-            // Previous button should be disabled
-            const prevButtonEl = element.shadowRoot.querySelector('.previous');
-            expect(prevButtonEl.disabled).toBeTruthy();
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        // Previous button should be disabled
+        const prevButtonEl = element.shadowRoot.querySelector('.previous');
+        expect(prevButtonEl.disabled).toBeTruthy();
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-paginator', {
             is: Paginator
         });
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/panelBar/__tests__/panelBar.test.js
+++ b/force-app/main/default/lwc/panelBar/__tests__/panelBar.test.js
@@ -9,12 +9,12 @@ describe('c-panel-bar', () => {
         }
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-panel-bar', {
             is: PanelBar
         });
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/panelBarWrapper/__tests__/panelBarWrapper.test.js
+++ b/force-app/main/default/lwc/panelBarWrapper/__tests__/panelBarWrapper.test.js
@@ -28,13 +28,13 @@ describe('c-panel-bar-wrapper', () => {
         expect(panelBarEl).not.toBeNull();
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-panel-bar-wrapper', {
             is: PanelBarWrapper
         });
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/panelGrid/__tests__/panelGrid.test.js
+++ b/force-app/main/default/lwc/panelGrid/__tests__/panelGrid.test.js
@@ -9,12 +9,12 @@ describe('c-panel-grid', () => {
         }
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-panel-grid', {
             is: PanelGrid
         });
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/panelGridWrapper/__tests__/panelGridWrapper.test.js
+++ b/force-app/main/default/lwc/panelGridWrapper/__tests__/panelGridWrapper.test.js
@@ -28,13 +28,13 @@ describe('c-panel-grid-wrapper', () => {
         expect(panelBarEl).not.toBeNull();
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-panel-grid-wrapper', {
             is: PanelGridWrapper
         });
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/singleRecords/__tests__/singleRecords.test.js
+++ b/force-app/main/default/lwc/singleRecords/__tests__/singleRecords.test.js
@@ -21,7 +21,13 @@ describe('c-single-records', () => {
         jest.clearAllMocks();
     });
 
-    it('renders UI with record', () => {
+    // Helper function to wait until the microtask queue is empty.
+    // Used to wait for asynchronous DOM updates.
+    async function flushPromises() {
+        return Promise.resolve();
+    }
+
+    it('renders UI with record', async () => {
         // Create initial element
         const element = createElement('c-single-records', {
             is: SingleRecords
@@ -31,18 +37,15 @@ describe('c-single-records', () => {
         // Emit record from @wire adapter to make it available to the component
         getSingleAccountViaSOQLAdapter.emit(mockGetSingleAccountViaSOQL);
 
-        // Return a promise to wait for any asynchronous DOM updates. Jest
-        // will automatically wait for the Promise chain to complete before
-        // ending the test and fail the test if the promise rejects.
-        return Promise.resolve().then(() => {
-            // Select elements for validation
-            const buttonEl =
-                element.shadowRoot.querySelector('lightning-button');
-            expect(buttonEl).not.toBeNull();
-        });
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        // Select elements for validation
+        const buttonEl = element.shadowRoot.querySelector('lightning-button');
+        expect(buttonEl).not.toBeNull();
     });
 
-    it('Navigates to Account page when Take me there! button is clicked', () => {
+    it('Navigates to Account page when Take me there! button is clicked', async () => {
         // Identify test values
         const INPUT_OBJECT = 'Account';
         const INPUT_TYPE = 'standard__recordPage';
@@ -58,28 +61,25 @@ describe('c-single-records', () => {
         // Emit record from @wire adapter to make it available to the component
         getSingleAccountViaSOQLAdapter.emit(mockGetSingleAccountViaSOQL);
 
-        // Return a promise to wait for any asynchronous DOM updates. Jest
-        // will automatically wait for the Promise chain to complete before
-        // ending the test and fail the test if the promise rejects.
-        return Promise.resolve().then(() => {
-            // Get button from the DOM and simulate user click
-            const buttonEl =
-                element.shadowRoot.querySelector('lightning-button');
-            buttonEl.click();
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
 
-            const { pageReference } = getNavigateCalledWith();
+        // Get button from the DOM and simulate user click
+        const buttonEl = element.shadowRoot.querySelector('lightning-button');
+        buttonEl.click();
 
-            // Verify the page reference is invoked with correct attributes
-            // according to test values above.
-            expect(pageReference.type).toBe(INPUT_TYPE);
-            expect(pageReference.attributes.objectApiName).toBe(INPUT_OBJECT);
-            expect(pageReference.attributes.recordId).toBe(RECORD_ID);
-            expect(pageReference.attributes.actionName).toBe(ACTION_NAME);
-        });
+        const { pageReference } = getNavigateCalledWith();
+
+        // Verify the page reference is invoked with correct attributes
+        // according to test values above.
+        expect(pageReference.type).toBe(INPUT_TYPE);
+        expect(pageReference.attributes.objectApiName).toBe(INPUT_OBJECT);
+        expect(pageReference.attributes.recordId).toBe(RECORD_ID);
+        expect(pageReference.attributes.actionName).toBe(ACTION_NAME);
     });
 
     describe('getSingleContact @wire error', () => {
-        it('shows error panel element', () => {
+        it('shows error panel element', async () => {
             const ERROR = { message: 'An error message' };
 
             // Create initial element
@@ -91,20 +91,18 @@ describe('c-single-records', () => {
             // Emit error from @wire
             getSingleAccountViaSOQLAdapter.error(ERROR);
 
-            // Return a promise to wait for any asynchronous DOM updates. Jest
-            // will automatically wait for the Promise chain to complete before
-            // ending the test and fail the test if the promise rejects.
-            return Promise.resolve().then(() => {
-                const errorPanelEl =
-                    element.shadowRoot.querySelector('c-error-panel');
-                // Ensure the error panel appears when there is an error state
-                expect(errorPanelEl).not.toBeNull();
-                expect(errorPanelEl.errors.body).toStrictEqual(ERROR);
-            });
+            // Wait for any asynchronous DOM updates
+            await flushPromises();
+
+            const errorPanelEl =
+                element.shadowRoot.querySelector('c-error-panel');
+            // Ensure the error panel appears when there is an error state
+            expect(errorPanelEl).not.toBeNull();
+            expect(errorPanelEl.errors.body).toStrictEqual(ERROR);
         });
     });
 
-    it('is accessible when data is returned', () => {
+    it('is accessible when data is returned', async () => {
         // Create initial element
         const element = createElement('c-single-records', {
             is: SingleRecords
@@ -114,10 +112,13 @@ describe('c-single-records', () => {
         // Emit record from @wire adapter to make it available to the component
         getSingleAccountViaSOQLAdapter.emit(mockGetSingleAccountViaSOQL);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        await expect(element).toBeAccessible();
     });
 
-    it('is accessible when error is returned', () => {
+    it('is accessible when error is returned', async () => {
         const ERROR = { message: 'An error message' };
 
         // Create initial element
@@ -132,6 +133,9 @@ describe('c-single-records', () => {
         // Emit record from @wire adapter to make it available to the component
         getSingleAccountViaSOQLAdapter.emit(mockGetSingleAccountViaSOQL);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/tabs/__tests__/tabs.test.js
+++ b/force-app/main/default/lwc/tabs/__tests__/tabs.test.js
@@ -9,12 +9,12 @@ describe('c-tabs', () => {
         }
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-tabs', {
             is: Tabs
         });
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/tabsWrapper/__tests__/tabsWrapper.test.js
+++ b/force-app/main/default/lwc/tabsWrapper/__tests__/tabsWrapper.test.js
@@ -26,13 +26,13 @@ describe('c-tabs-wrapper', () => {
         expect(innerEl).not.toBeNull();
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-tabs-wrapper', {
             is: TabsWrapper
         });
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/toolbar/__tests__/toolbar.test.js
+++ b/force-app/main/default/lwc/toolbar/__tests__/toolbar.test.js
@@ -9,12 +9,12 @@ describe('c-toolbar', () => {
         }
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-toolbar', {
             is: Toolbar
         });
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/toolbarWrapper/__tests__/toolbarWrapper.test.js
+++ b/force-app/main/default/lwc/toolbarWrapper/__tests__/toolbarWrapper.test.js
@@ -26,12 +26,12 @@ describe('c-toolbar-wrapper', () => {
         expect(innerEl).not.toBeNull();
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-toolbar-wrapper', {
             is: ToolbarWrapper
         });
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/viewRecord/__tests__/viewRecord.test.js
+++ b/force-app/main/default/lwc/viewRecord/__tests__/viewRecord.test.js
@@ -41,13 +41,13 @@ describe('c-view-record', () => {
         ]);
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-view-record', {
             is: ViewRecord
         });
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/viewRecordWithParentRecordData/__tests__/viewRecordWithParentRecordData.test.js
+++ b/force-app/main/default/lwc/viewRecordWithParentRecordData/__tests__/viewRecordWithParentRecordData.test.js
@@ -24,7 +24,13 @@ describe('c-view-record-with-parent-record-data', () => {
         jest.clearAllMocks();
     });
 
-    it('contains one lightning-record-view-form with three lightning-output-fields and one lightning-formatted-text', () => {
+    // Helper function to wait until the microtask queue is empty.
+    // Used to wait for asynchronous DOM updates.
+    async function flushPromises() {
+        return Promise.resolve();
+    }
+
+    it('contains one lightning-record-view-form with three lightning-output-fields and one lightning-formatted-text', async () => {
         // Create initial element
         const element = createElement('c-view-record-with-parent-record-data', {
             is: ViewRecordWithParentRecordData
@@ -46,7 +52,7 @@ describe('c-view-record-with-parent-record-data', () => {
         expect(formattedTextEl).not.toBeNull();
     });
 
-    it('uses the account object and account field within lightning-record-view-form', () => {
+    it('uses the account object and account field within lightning-record-view-form', async () => {
         const ACCOUNT_FIELDS = [
             ACCOUNT_NAME_FIELD,
             ACCOUNT_TYPE_FIELD,
@@ -74,7 +80,7 @@ describe('c-view-record-with-parent-record-data', () => {
     });
 
     describe('@wire getRecord', () => {
-        it('gets called to query the account owner name field', () => {
+        it('gets called to query the account owner name field', async () => {
             const RECORD_ID = '0012100000rZPJFAA4';
 
             // Create initial element
@@ -91,18 +97,16 @@ describe('c-view-record-with-parent-record-data', () => {
             // Emit data from @wire
             getRecordAdapter.emit(mockGetRecord);
 
-            // Return a promise to wait for any asynchronous DOM updates. Jest
-            // will automatically wait for the Promise chain to complete before
-            // ending the test and fail the test if the promise rejects.
-            return Promise.resolve().then(() => {
-                expect(getRecordAdapter.getLastConfig()).toEqual({
-                    recordId: RECORD_ID,
-                    fields: [ACCOUNT_OWNER_NAME_FIELD]
-                });
+            // Wait for any asynchronous DOM updates
+            await flushPromises();
+
+            expect(getRecordAdapter.getLastConfig()).toEqual({
+                recordId: RECORD_ID,
+                fields: [ACCOUNT_OWNER_NAME_FIELD]
             });
         });
 
-        it('shows the account owner name on successful emit', () => {
+        it('shows the account owner name on successful emit', async () => {
             // Create initial element
             const element = createElement(
                 'c-view-record-with-parent-record-data',
@@ -115,20 +119,18 @@ describe('c-view-record-with-parent-record-data', () => {
             // Emit data from @wire
             getRecordAdapter.emit(mockGetRecord);
 
-            // Return a promise to wait for any asynchronous DOM updates. Jest
-            // will automatically wait for the Promise chain to complete before
-            // ending the test and fail the test if the promise rejects.
-            return Promise.resolve().then(() => {
-                const textEl = element.shadowRoot.querySelector(
-                    'lightning-formatted-text'
-                );
-                expect(textEl.value).toEqual(
-                    mockGetRecord.fields.Owner.value.fields.Name.value
-                );
-            });
+            // Wait for any asynchronous DOM updates
+            await flushPromises();
+
+            const textEl = element.shadowRoot.querySelector(
+                'lightning-formatted-text'
+            );
+            expect(textEl.value).toEqual(
+                mockGetRecord.fields.Owner.value.fields.Name.value
+            );
         });
 
-        it('shows an empty value for the account owner name on error emit', () => {
+        it('shows an empty value for the account owner name on error emit', async () => {
             // Create initial element
             const element = createElement(
                 'c-view-record-with-parent-record-data',
@@ -141,25 +143,23 @@ describe('c-view-record-with-parent-record-data', () => {
             // Emit data from @wire
             getRecordAdapter.error();
 
-            // Return a promise to wait for any asynchronous DOM updates. Jest
-            // will automatically wait for the Promise chain to complete before
-            // ending the test and fail the test if the promise rejects.
-            return Promise.resolve().then(() => {
-                const textEl = element.shadowRoot.querySelector(
-                    'lightning-formatted-text'
-                );
-                expect(textEl.value).toBe('');
-            });
+            // Wait for any asynchronous DOM updates
+            await flushPromises();
+
+            const textEl = element.shadowRoot.querySelector(
+                'lightning-formatted-text'
+            );
+            expect(textEl.value).toBe('');
         });
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-view-record-with-parent-record-data', {
             is: ViewRecordWithParentRecordData
         });
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/viewRecordWithParentRecordDataWrapper/__tests__/viewRecordWithParentRecordDataWrapper.test.js
+++ b/force-app/main/default/lwc/viewRecordWithParentRecordDataWrapper/__tests__/viewRecordWithParentRecordDataWrapper.test.js
@@ -54,7 +54,7 @@ describe('c-view-record-with-parent-record-data-wrapper', () => {
         expect(innerEl.recordId).toBe(RECORD_ID);
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement(
             'c-view-record-with-parent-record-data-wrapper',
             {
@@ -64,6 +64,6 @@ describe('c-view-record-with-parent-record-data-wrapper', () => {
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });

--- a/force-app/main/default/lwc/viewRecordWrapper/__tests__/viewRecordWrapper.test.js
+++ b/force-app/main/default/lwc/viewRecordWrapper/__tests__/viewRecordWrapper.test.js
@@ -42,13 +42,13 @@ describe('c-view-record-wrapper', () => {
         expect(viewRecordEl.recordId).toBe(RECORD_ID);
     });
 
-    it('is accessible', () => {
+    it('is accessible', async () => {
         const element = createElement('c-view-record-wrapper', {
             is: ViewRecordWrapper
         });
 
         document.body.appendChild(element);
 
-        return Promise.resolve().then(() => expect(element).toBeAccessible());
+        await expect(element).toBeAccessible();
     });
 });


### PR DESCRIPTION
### What does this PR do?
Refactor tests to use async await

### What issues does this PR fix or reference?

#<Insert GitHub Issue>

## The PR fulfills these requirements:

[X] Tests for the proposed changes have been added/updated.
[X] Code linting and formatting was performed.

### Functionality Before

Tests used promise.resolve.then to wait for async DOM updates

### Functionality After

Tests use async / await instead
